### PR TITLE
Rename CallConv::Native to CallConv::SystemV.

### DIFF
--- a/docs/callex.cton
+++ b/docs/callex.cton
@@ -1,6 +1,6 @@
 test verifier
 
-function %gcd(i32 uext, i32 uext) -> i32 uext native {
+function %gcd(i32 uext, i32 uext) -> i32 uext system_v {
     fn1 = function %divmod(i32 uext, i32 uext) -> i32 uext, i32 uext
 
 ebb1(v1: i32, v2: i32):

--- a/docs/example.cton
+++ b/docs/example.cton
@@ -1,6 +1,6 @@
 test verifier
 
-function %average(i32, i32) -> f32 native {
+function %average(i32, i32) -> f32 system_v {
     ss1 = explicit_slot 8         ; Stack slot for ``sum``.
 
 ebb1(v1: i32, v2: i32):

--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -400,11 +400,11 @@ convention:
     param        : type [paramext] [paramspecial]
     paramext     : "uext" | "sext"
     paramspecial : "sret" | "link" | "fp" | "csr" | "vmctx"
-    callconv     : "native" | "spiderwasm"
+    callconv     : "system_v" | "spiderwasm"
 
 Parameters and return values have flags whose meaning is mostly target
-dependent. They make it possible to call native functions on the target
-platform. When calling other Cretonne functions, the flags are not necessary.
+dependent. These flags support interfacing with code produced by other
+compilers.
 
 Functions that are called directly must be declared in the :term:`function
 preamble`:

--- a/filetests/domtree/loops.cton
+++ b/filetests/domtree/loops.cton
@@ -59,7 +59,7 @@ function %test(i32) {
 ; nextln: ebb5:
 ; nextln: }
 
-function %loop2(i32) native {
+function %loop2(i32) system_v {
     ebb0(v0: i32):
         brz v0, ebb1    ; dominates: ebb1 ebb3 ebb4 ebb5
         jump ebb2       ; dominates: ebb2

--- a/filetests/domtree/loops2.cton
+++ b/filetests/domtree/loops2.cton
@@ -43,7 +43,7 @@ function %loop1(i32) {
 ; nextln: ebb9:
 ; nextln: }
 
-function %loop2(i32) native {
+function %loop2(i32) system_v {
     ebb0(v0: i32):
         brz v0, ebb1    ; dominates: ebb1 ebb3 ebb4 ebb5
         jump ebb2       ; dominates: ebb2

--- a/filetests/isa/intel/abi-bool.cton
+++ b/filetests/isa/intel/abi-bool.cton
@@ -2,7 +2,7 @@ test compile
 set is_64bit=1
 isa intel haswell
 
-function %foo(i64, i64, i64, i32) -> b1 native {
+function %foo(i64, i64, i64, i32) -> b1 system_v {
 ebb3(v0: i64, v1: i64, v2: i64, v3: i32):
     v5 = icmp ne v2, v2
     v8 = iconst.i64 0

--- a/filetests/isa/intel/abi32.cton
+++ b/filetests/isa/intel/abi32.cton
@@ -5,14 +5,14 @@ isa intel
 ; regex: V=v\d+
 
 function %f() {
-    sig0 = (i32) -> i32 native
-    ; check: sig0 = (i32 [0]) -> i32 [%rax] native
+    sig0 = (i32) -> i32 system_v
+    ; check: sig0 = (i32 [0]) -> i32 [%rax] system_v
 
-    sig1 = (i64) -> b1 native
-    ; check: sig1 = (i32 [0], i32 [4]) -> b1 [%rax] native
+    sig1 = (i64) -> b1 system_v
+    ; check: sig1 = (i32 [0], i32 [4]) -> b1 [%rax] system_v
 
-    sig2 = (f32, i64) -> f64 native
-    ; check: sig2 = (f32 [0], i32 [4], i32 [8]) -> f64 [%xmm0] native
+    sig2 = (f32, i64) -> f64 system_v
+    ; check: sig2 = (f32 [0], i32 [4], i32 [8]) -> f64 [%xmm0] system_v
 
 ebb0:
     return

--- a/filetests/isa/intel/abi64.cton
+++ b/filetests/isa/intel/abi64.cton
@@ -6,14 +6,14 @@ isa intel
 ; regex: V=v\d+
 
 function %f() {
-    sig0 = (i32) -> i32 native
-    ; check: sig0 = (i32 [%rdi]) -> i32 [%rax] native
+    sig0 = (i32) -> i32 system_v
+    ; check: sig0 = (i32 [%rdi]) -> i32 [%rax] system_v
 
-    sig1 = (i64) -> b1 native
-    ; check: sig1 = (i64 [%rdi]) -> b1 [%rax] native
+    sig1 = (i64) -> b1 system_v
+    ; check: sig1 = (i64 [%rdi]) -> b1 [%rax] system_v
 
-    sig2 = (f32, i64) -> f64 native
-    ; check: sig2 = (f32 [%xmm0], i64 [%rdi]) -> f64 [%xmm0] native
+    sig2 = (f32, i64) -> f64 system_v
+    ; check: sig2 = (f32 [%xmm0], i64 [%rdi]) -> f64 [%xmm0] system_v
 
 ebb0:
     return

--- a/filetests/isa/intel/legalize-libcall.cton
+++ b/filetests/isa/intel/legalize-libcall.cton
@@ -9,7 +9,7 @@ ebb0(v0: f32):
     v1 = floor v0
     return v1
 }
-; check: function %floor(f32 [%xmm0]) -> f32 [%xmm0] native {
-; check: sig0 = (f32) -> f32 native
+; check: function %floor(f32 [%xmm0]) -> f32 [%xmm0] system_v {
+; check: sig0 = (f32) -> f32 system_v
 ; check: fn0 = sig0 %FloorF32
 ; check: v1 = call fn0(v0)

--- a/filetests/isa/intel/prologue-epilogue.cton
+++ b/filetests/isa/intel/prologue-epilogue.cton
@@ -9,7 +9,7 @@ ebb0:
     return
 }
 
-; check: function %foo(i64 fp [%rbp], i64 csr [%rbx], i64 csr [%r12], i64 csr [%r13], i64 csr [%r14], i64 csr [%r15]) -> i64 fp [%rbp], i64 csr [%rbx], i64 csr [%r12], i64 csr [%r13], i64 csr [%r14], i64 csr [%r15] native {
+; check: function %foo(i64 fp [%rbp], i64 csr [%rbx], i64 csr [%r12], i64 csr [%r13], i64 csr [%r14], i64 csr [%r15]) -> i64 fp [%rbp], i64 csr [%rbx], i64 csr [%r12], i64 csr [%r13], i64 csr [%r14], i64 csr [%r15] system_v {
 ; nextln:     ss0 = explicit_slot 168, offset -224
 ; nextln:     ss1 = incoming_arg 56, offset -56
 ; check: ebb0(v0: i64 [%rbp], v1: i64 [%rbx], v2: i64 [%r12], v3: i64 [%r13], v4: i64 [%r14], v5: i64 [%r15]):

--- a/filetests/isa/riscv/abi-e.cton
+++ b/filetests/isa/riscv/abi-e.cton
@@ -7,8 +7,8 @@ isa riscv enable_e
 function %f() {
     ; Spilling into the stack args after %x15 since %16 and up are not
     ; available in RV32E.
-    sig0 = (i64, i64, i64, i64) -> i64 native
-    ; check: sig0 = (i32 [%x10], i32 [%x11], i32 [%x12], i32 [%x13], i32 [%x14], i32 [%x15], i32 [0], i32 [4]) -> i32 [%x10], i32 [%x11] native
+    sig0 = (i64, i64, i64, i64) -> i64 system_v
+    ; check: sig0 = (i32 [%x10], i32 [%x11], i32 [%x12], i32 [%x13], i32 [%x14], i32 [%x15], i32 [0], i32 [4]) -> i32 [%x10], i32 [%x11] system_v
 ebb0:
     return
 }

--- a/filetests/isa/riscv/abi.cton
+++ b/filetests/isa/riscv/abi.cton
@@ -5,27 +5,27 @@ isa riscv
 ; regex: V=v\d+
 
 function %f() {
-    sig0 = (i32) -> i32 native
-    ; check: sig0 = (i32 [%x10]) -> i32 [%x10] native
+    sig0 = (i32) -> i32 system_v
+    ; check: sig0 = (i32 [%x10]) -> i32 [%x10] system_v
 
-    sig1 = (i64) -> b1 native
-    ; check: sig1 = (i32 [%x10], i32 [%x11]) -> b1 [%x10] native
+    sig1 = (i64) -> b1 system_v
+    ; check: sig1 = (i32 [%x10], i32 [%x11]) -> b1 [%x10] system_v
 
     ; The i64 argument must go in an even-odd register pair.
-    sig2 = (f32, i64) -> f64 native
-    ; check: sig2 = (f32 [%f10], i32 [%x12], i32 [%x13]) -> f64 [%f10] native
+    sig2 = (f32, i64) -> f64 system_v
+    ; check: sig2 = (f32 [%f10], i32 [%x12], i32 [%x13]) -> f64 [%f10] system_v
 
     ; Spilling into the stack args.
-    sig3 = (f64, f64, f64, f64, f64, f64, f64, i64) -> f64 native
-    ; check: sig3 = (f64 [%f10], f64 [%f11], f64 [%f12], f64 [%f13], f64 [%f14], f64 [%f15], f64 [%f16], i32 [0], i32 [4]) -> f64 [%f10] native
+    sig3 = (f64, f64, f64, f64, f64, f64, f64, i64) -> f64 system_v
+    ; check: sig3 = (f64 [%f10], f64 [%f11], f64 [%f12], f64 [%f13], f64 [%f14], f64 [%f15], f64 [%f16], i32 [0], i32 [4]) -> f64 [%f10] system_v
 
     ; Splitting vectors.
-    sig4 = (i32x4) native
-    ; check: sig4 = (i32 [%x10], i32 [%x11], i32 [%x12], i32 [%x13]) native
+    sig4 = (i32x4) system_v
+    ; check: sig4 = (i32 [%x10], i32 [%x11], i32 [%x12], i32 [%x13]) system_v
 
     ; Splitting vectors, then splitting ints.
-    sig5 = (i64x4) native
-    ; check: sig5 = (i32 [%x10], i32 [%x11], i32 [%x12], i32 [%x13], i32 [%x14], i32 [%x15], i32 [%x16], i32 [%x17]) native
+    sig5 = (i64x4) system_v
+    ; check: sig5 = (i32 [%x10], i32 [%x11], i32 [%x12], i32 [%x13], i32 [%x14], i32 [%x15], i32 [%x16], i32 [%x17]) system_v
 
 ebb0:
     return

--- a/filetests/isa/riscv/legalize-abi.cton
+++ b/filetests/isa/riscv/legalize-abi.cton
@@ -106,7 +106,7 @@ ebb0(v0: i64x4):
 }
 
 function %indirect(i32) {
-    sig1 = () native
+    sig1 = () system_v
 ebb0(v0: i32):
     call_indirect sig1, v0()
     return
@@ -114,7 +114,7 @@ ebb0(v0: i32):
 
 ; The first argument to call_indirect doesn't get altered.
 function %indirect_arg(i32, f32x2) {
-    sig1 = (f32x2) native
+    sig1 = (f32x2) system_v
 ebb0(v0: i32, v1: f32x2):
     call_indirect sig1, v0(v1)
     ; check: call_indirect sig1, v0($V, $V)

--- a/filetests/isa/riscv/parse-encoding.cton
+++ b/filetests/isa/riscv/parse-encoding.cton
@@ -3,32 +3,32 @@ test legalizer
 isa riscv
 
 function %parse_encoding(i32 [%x5]) -> i32 [%x10] {
-    ; check: function %parse_encoding(i32 [%x5], i32 link [%x1]) -> i32 [%x10], i32 link [%x1] native {
+    ; check: function %parse_encoding(i32 [%x5], i32 link [%x1]) -> i32 [%x10], i32 link [%x1] system_v {
 
-    sig0 = (i32 [%x10]) -> i32 [%x10] native
-    ; check: sig0 = (i32 [%x10]) -> i32 [%x10] native
+    sig0 = (i32 [%x10]) -> i32 [%x10] system_v
+    ; check: sig0 = (i32 [%x10]) -> i32 [%x10] system_v
 
-    sig1 = (i32 [%x10], i32 [%x11]) -> b1 [%x10] native
-    ; check: sig1 = (i32 [%x10], i32 [%x11]) -> b1 [%x10] native
+    sig1 = (i32 [%x10], i32 [%x11]) -> b1 [%x10] system_v
+    ; check: sig1 = (i32 [%x10], i32 [%x11]) -> b1 [%x10] system_v
 
-    sig2 = (f32 [%f10], i32 [%x12], i32 [%x13]) -> f64 [%f10] native
-    ; check: sig2 = (f32 [%f10], i32 [%x12], i32 [%x13]) -> f64 [%f10] native
+    sig2 = (f32 [%f10], i32 [%x12], i32 [%x13]) -> f64 [%f10] system_v
+    ; check: sig2 = (f32 [%f10], i32 [%x12], i32 [%x13]) -> f64 [%f10] system_v
 
     ; Arguments on stack where not necessary
-    sig3 = (f64 [%f10], i32 [0], i32 [4]) -> f64 [%f10] native
-    ; check: sig3 = (f64 [%f10], i32 [0], i32 [4]) -> f64 [%f10] native
+    sig3 = (f64 [%f10], i32 [0], i32 [4]) -> f64 [%f10] system_v
+    ; check: sig3 = (f64 [%f10], i32 [0], i32 [4]) -> f64 [%f10] system_v
 
     ; Stack argument before register argument
-    sig4 = (f32 [72], i32 [%x10]) native
-    ; check: sig4 = (f32 [72], i32 [%x10]) native
+    sig4 = (f32 [72], i32 [%x10]) system_v
+    ; check: sig4 = (f32 [72], i32 [%x10]) system_v
 
     ; Return value on stack
-    sig5 = () -> f32 [0] native
-    ; check: sig5 = () -> f32 [0] native
+    sig5 = () -> f32 [0] system_v
+    ; check: sig5 = () -> f32 [0] system_v
 
     ; function + signature
-    fn0 = function %bar(i32 [%x10]) -> b1 [%x10] native
-    ; check: sig6 = (i32 [%x10]) -> b1 [%x10] native
+    fn0 = function %bar(i32 [%x10]) -> b1 [%x10] system_v
+    ; check: sig6 = (i32 [%x10]) -> b1 [%x10] system_v
     ; nextln: fn0 = sig6 %bar
 
 ebb0(v0: i32):

--- a/filetests/licm/complex.cton
+++ b/filetests/licm/complex.cton
@@ -1,6 +1,6 @@
 test licm
 
-function %complex(i32) -> i32 native {
+function %complex(i32) -> i32 system_v {
 ebb0(v0: i32):
     jump ebb1(v0)
 

--- a/filetests/parser/branch.cton
+++ b/filetests/parser/branch.cton
@@ -9,7 +9,7 @@ ebb0:
 ebb1:
     jump ebb0()
 }
-; sameln: function %minimal() native {
+; sameln: function %minimal() system_v {
 ; nextln: ebb0:
 ; nextln:     jump ebb1
 ; nextln: 
@@ -25,7 +25,7 @@ ebb0(v90: i32):
 ebb1(v91: i32):
     jump ebb0(v91)
 }
-; sameln: function %onearg(i32) native {
+; sameln: function %onearg(i32) system_v {
 ; nextln: ebb0(v90: i32):
 ; nextln:     jump ebb1(v90)
 ; nextln: 
@@ -41,7 +41,7 @@ ebb0(v90: i32, v91: f32):
 ebb1(v92: i32, v93: f32):
     jump ebb0(v92, v93)
 }
-; sameln: function %twoargs(i32, f32) native {
+; sameln: function %twoargs(i32, f32) system_v {
 ; nextln: ebb0(v90: i32, v91: f32):
 ; nextln:     jump ebb1(v90, v91)
 ; nextln: 
@@ -57,7 +57,7 @@ ebb0(v90: i32):
 ebb1:
     brnz v90, ebb1()
 }
-; sameln: function %minimal(i32) native {
+; sameln: function %minimal(i32) system_v {
 ; nextln: ebb0(v90: i32):
 ; nextln:     brz v90, ebb1
 ; nextln: 
@@ -72,7 +72,7 @@ ebb0(v90: i32, v91: f32):
 ebb1(v92: i32, v93: f32):
     brnz v90, ebb0(v92, v93)
 }
-; sameln: function %twoargs(i32, f32) native {
+; sameln: function %twoargs(i32, f32) system_v {
 ; nextln: ebb0(v90: i32, v91: f32):
 ; nextln:     brz v90, ebb1(v90, v91)
 ; nextln: 
@@ -94,7 +94,7 @@ ebb30:
 ebb40:
     trap user4
 }
-; sameln: function %jumptable(i32) native {
+; sameln: function %jumptable(i32) system_v {
 ; check:      jt2 = jump_table 0, 0, ebb10, ebb40, ebb20, ebb30
 ; check:      jt200 = jump_table 0
 ; check:  ebb10(v3: i32):

--- a/filetests/parser/call.cton
+++ b/filetests/parser/call.cton
@@ -5,7 +5,7 @@ function %mini() {
 ebb1:
     return
 }
-; sameln: function %mini() native {
+; sameln: function %mini() system_v {
 ; nextln: ebb1:
 ; nextln:     return
 ; nextln: }
@@ -29,10 +29,10 @@ function %signatures() {
     fn5 = sig11 %foo
     fn8 = function %bar(i32) -> b1
 }
-; sameln: function %signatures() native {
-; check:      sig10 = () native
+; sameln: function %signatures() system_v {
+; check:      sig10 = () system_v
 ; check:      sig11 = (i32, f64) -> i32, b1 spiderwasm
-; check:      sig12 = (i32) -> b1 native
+; check:      sig12 = (i32) -> b1 system_v
 ; not:        fn0
 ; check:      fn5 = sig11 %foo
 ; check:      fn8 = sig12 %bar
@@ -88,7 +88,7 @@ function %special1(i32 sret, i32 fp, i32 csr, i32 link) -> i32 link, i32 fp, i32
 ebb0(v1: i32, v2: i32, v3: i32, v4: i32):
     return v4, v2, v3, v1
 }
-; check: function %special1(i32 sret, i32 fp, i32 csr, i32 link) -> i32 link, i32 fp, i32 csr, i32 sret native {
+; check: function %special1(i32 sret, i32 fp, i32 csr, i32 link) -> i32 link, i32 fp, i32 csr, i32 sret system_v {
 ; check: ebb0(v1: i32, v2: i32, v3: i32, v4: i32):
 ; check:     return v4, v2, v3, v1
 ; check: }

--- a/filetests/parser/instruction_encoding.cton
+++ b/filetests/parser/instruction_encoding.cton
@@ -13,7 +13,7 @@ ebb1(v0: i32 [%x8], v1: i32):
 @55 v9 = iadd v8, v7
 @a5 [Iret#5] return v0, v8
 }
-; sameln: function %foo(i32, i32) native {
+; sameln: function %foo(i32, i32) system_v {
 ; nextln: ebb1(v0: i32 [%x8], v1: i32):
 ; nextln:     [-,-]$WS v2 = iadd v0, v1
 ; nextln:     [-]$WS trap heap_oob

--- a/filetests/parser/keywords.cton
+++ b/filetests/parser/keywords.cton
@@ -2,4 +2,4 @@ test cat
 
 ; 'function' is not a keyword, and can be used as the name of a function too.
 function %function() {}
-; check: function %function() native
+; check: function %function() system_v

--- a/filetests/parser/rewrite.cton
+++ b/filetests/parser/rewrite.cton
@@ -9,7 +9,7 @@ ebb100(v20: i32):
     v9200 = f64const 0x4.0p0
     trap user4
 }
-; sameln: function %defs() native {
+; sameln: function %defs() system_v {
 ; nextln: ebb100(v20: i32):
 ; nextln:     v1000 = iconst.i32x8 5
 ; nextln:     v9200 = f64const 0x1.0000000000000p2
@@ -23,7 +23,7 @@ ebb100(v20: i32):
     v200 = iadd v20, v1000
     jump ebb100(v1000)
 }
-; sameln: function %use_value() native {
+; sameln: function %use_value() system_v {
 ; nextln: ebb100(v20: i32):
 ; nextln:     v1000 = iadd_imm v20, 5
 ; nextln:     v200 = iadd v20, v1000

--- a/filetests/parser/tiny.cton
+++ b/filetests/parser/tiny.cton
@@ -5,7 +5,7 @@ function %minimal() {
 ebb0:
     trap user0
 }
-; sameln: function %minimal() native {
+; sameln: function %minimal() system_v {
 ; nextln: ebb0:
 ; nextln:     trap user0
 ; nextln: }
@@ -18,7 +18,7 @@ ebb0:
     v1 = iconst.i8 6
     v2 = ishl v0, v1
 }
-; sameln: function %ivalues() native {
+; sameln: function %ivalues() system_v {
 ; nextln: ebb0:
 ; nextln:     v0 = iconst.i32 2
 ; nextln:     v1 = iconst.i8 6
@@ -34,7 +34,7 @@ ebb0:
     v2 = bextend.b32 v1
     v3 = bxor v0, v2
 }
-; sameln: function %bvalues() native {
+; sameln: function %bvalues() system_v {
 ; nextln: ebb0:
 ; nextln:     v0 = bconst.b32 true
 ; nextln:     v1 = bconst.b8 false
@@ -47,17 +47,17 @@ function %select() {
 ebb0(v90: i32, v91: i32, v92: b1):
     v0 = select v92, v90, v91
 }
-; sameln: function %select() native {
+; sameln: function %select() system_v {
 ; nextln: ebb0(v90: i32, v91: i32, v92: b1):
 ; nextln:     v0 = select v92, v90, v91
 ; nextln: }
 
 ; Polymorphic instruction controlled by third operand.
-function %selectif() native {
+function %selectif() system_v {
 ebb0(v95: i32, v96: i32, v97: b1):
     v98 = selectif.i32 eq v97, v95, v96
 }
-; sameln: function %selectif() native {
+; sameln: function %selectif() system_v {
 ; nextln: ebb0(v95: i32, v96: i32, v97: b1):
 ; nextln: v98 = selectif.i32 eq v97, v95, v96
 ; nextln: }
@@ -69,7 +69,7 @@ ebb0:
     v1 = extractlane v0, 3
     v2 = insertlane v0, 1, v1
 }
-; sameln: function %lanes() native {
+; sameln: function %lanes() system_v {
 ; nextln: ebb0:
 ; nextln:     v0 = iconst.i32x4 2
 ; nextln:     v1 = extractlane v0, 3
@@ -85,7 +85,7 @@ ebb0(v90: i32, v91: i32):
     v3 = irsub_imm v91, 45
     br_icmp eq v90, v91, ebb0(v91, v90)
 }
-; sameln: function %icmp(i32, i32) native {
+; sameln: function %icmp(i32, i32) system_v {
 ; nextln: ebb0(v90: i32, v91: i32):
 ; nextln:     v0 = icmp eq v90, v91
 ; nextln:     v1 = icmp ult v90, v91
@@ -101,7 +101,7 @@ ebb0(v90: f32, v91: f32):
     v1 = fcmp uno v90, v91
     v2 = fcmp lt v90, v91
 }
-; sameln: function %fcmp(f32, f32) native {
+; sameln: function %fcmp(f32, f32) system_v {
 ; nextln: ebb0(v90: f32, v91: f32):
 ; nextln:     v0 = fcmp eq v90, v91
 ; nextln:     v1 = fcmp uno v90, v91
@@ -115,7 +115,7 @@ ebb0(v90: i32, v91: f32):
     v0 = bitcast.i8x4 v90
     v1 = bitcast.i32 v91
 }
-; sameln: function %bitcast(i32, f32) native {
+; sameln: function %bitcast(i32, f32) system_v {
 ; nextln: ebb0(v90: i32, v91: f32):
 ; nextln:     v0 = bitcast.i8x4 v90
 ; nextln:     v1 = bitcast.i32 v91
@@ -135,7 +135,7 @@ ebb0:
     stack_store v1, ss10+2
     stack_store v2, ss2
 }
-; sameln: function %stack() native {
+; sameln: function %stack() system_v {
 ; check:     ss2 = explicit_slot 4
 ; check:     ss3 = incoming_arg 4, offset 8
 ; check:     ss4 = outgoing_arg 4
@@ -162,7 +162,7 @@ ebb0(v1: i32):
     store aligned v3, v1+12
     store notrap aligned v3, v1-12
 }
-; sameln: function %memory(i32) native {
+; sameln: function %memory(i32) system_v {
 ; nextln: ebb0(v1: i32):
 ; nextln:     v2 = load.i64 v1
 ; nextln:     v3 = load.i64 aligned v1
@@ -187,7 +187,7 @@ ebb0(v1: i32):
     regfill v1, ss0 -> %10
     return
 }
-; sameln: function %diversion(i32) native {
+; sameln: function %diversion(i32) system_v {
 ; nextln:     ss0 = spill_slot 4
 ; check: ebb0(v1: i32):
 ; nextln:     regmove v1, %10 -> %20
@@ -204,7 +204,7 @@ ebb0:
     copy_special %20 -> %10
     return
 }
-; sameln: function %copy_special() native {
+; sameln: function %copy_special() system_v {
 ; nextln: ebb0:
 ; nextln:     copy_special %10 -> %20
 ; nextln:     copy_special %20 -> %10

--- a/filetests/regalloc/coalesce.cton
+++ b/filetests/regalloc/coalesce.cton
@@ -109,7 +109,7 @@ ebb1(v10: i32):
     return v11
 }
 
-function %gvn_unremovable_phi(i32) native {
+function %gvn_unremovable_phi(i32) system_v {
 ebb0(v0: i32):
     v2 = iconst.i32 0
     jump ebb2(v2, v0)

--- a/filetests/regalloc/coalescing-207.cton
+++ b/filetests/regalloc/coalescing-207.cton
@@ -5,12 +5,12 @@ isa intel haswell
 ; Reported as https://github.com/Cretonne/cretonne/issues/207
 ;
 ; The coalescer creates a virtual register with two interfering values.
-function %pr207(i64 vmctx, i32, i32) -> i32 native {
+function %pr207(i64 vmctx, i32, i32) -> i32 system_v {
     gv0 = vmctx-8
     heap0 = static gv0, min 0, bound 0x5000, guard 0x0040_0000
-    sig0 = (i64 vmctx, i32, i32) -> i32 native
-    sig1 = (i64 vmctx, i32, i32, i32) -> i32 native
-    sig2 = (i64 vmctx, i32, i32, i32) -> i32 native
+    sig0 = (i64 vmctx, i32, i32) -> i32 system_v
+    sig1 = (i64 vmctx, i32, i32, i32) -> i32 system_v
+    sig2 = (i64 vmctx, i32, i32, i32) -> i32 system_v
     fn0 = sig0 u0:2
     fn1 = sig1 u0:0
     fn2 = sig2 u0:1
@@ -1034,10 +1034,10 @@ ebb92(v767: i32):
 }
 
 ; Same problem from musl.wasm.
-function %musl(f64 [%xmm0], i64 vmctx [%rdi]) -> f64 [%xmm0] native {
+function %musl(f64 [%xmm0], i64 vmctx [%rdi]) -> f64 [%xmm0] system_v {
     gv0 = vmctx
     heap0 = static gv0, min 0, bound 0x0001_0000_0000, guard 0x8000_0000
-    sig0 = (f64 [%xmm0], i32 [%rdi], i64 vmctx [%rsi]) -> f64 [%xmm0] native
+    sig0 = (f64 [%xmm0], i32 [%rdi], i64 vmctx [%rsi]) -> f64 [%xmm0] system_v
     fn0 = sig0 u0:517
 
 ebb0(v0: f64, v1: i64):

--- a/filetests/regalloc/coalescing-216.cton
+++ b/filetests/regalloc/coalescing-216.cton
@@ -5,7 +5,7 @@ isa intel haswell
 ; Reported as https://github.com/Cretonne/cretonne/issues/216 from the Binaryen fuzzer.
 ;
 ; The (old) coalescer creates a virtual register with two identical values.
-function %pr216(i32 [%rdi], i64 vmctx [%rsi]) -> i64 [%rax] native {
+function %pr216(i32 [%rdi], i64 vmctx [%rsi]) -> i64 [%rax] system_v {
 ebb0(v0: i32, v1: i64):
     v3 = iconst.i64 0
     v5 = iconst.i32 0

--- a/filetests/regalloc/coloring-227.cton
+++ b/filetests/regalloc/coloring-227.cton
@@ -2,7 +2,7 @@ test regalloc
 set is_64bit
 isa intel haswell
 
-function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8]) native {
+function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8]) system_v {
     gv0 = vmctx
     heap0 = static gv0, min 0, bound 0x0001_0000_0000, guard 0x8000_0000
 

--- a/filetests/regalloc/ghost-param.cton
+++ b/filetests/regalloc/ghost-param.cton
@@ -9,7 +9,7 @@ isa intel haswell
 ;
 ; Test case by binaryen fuzzer!
 
-function %pr215(i64 vmctx [%rdi]) native {
+function %pr215(i64 vmctx [%rdi]) system_v {
 ebb0(v0: i64):
     v10 = iconst.i64 0
     v1 = bitcast.f64 v10

--- a/filetests/regalloc/global-fixed.cton
+++ b/filetests/regalloc/global-fixed.cton
@@ -2,7 +2,7 @@ test regalloc
 set is_64bit=1
 isa intel haswell
 
-function %foo() native {
+function %foo() system_v {
 ebb4:
     v3 = iconst.i32 0
     jump ebb3

--- a/filetests/regalloc/intel-regres.cton
+++ b/filetests/regalloc/intel-regres.cton
@@ -11,7 +11,7 @@ isa intel
 ; This ended up confusong the constraint solver which had not made a record of
 ; the fixed register assignment for v9 since it was already in the correct
 ; register.
-function %pr147(i32) -> i32 native {
+function %pr147(i32) -> i32 system_v {
 ebb0(v0: i32):
     v1 = iconst.i32 0
     v2 = iconst.i32 1

--- a/filetests/regalloc/output-interference.cton
+++ b/filetests/regalloc/output-interference.cton
@@ -2,7 +2,7 @@ test regalloc
 set is_64bit=1
 isa intel haswell
 
-function %test(i64) -> i64 native {
+function %test(i64) -> i64 system_v {
 ebb0(v0: i64):
     v2 = iconst.i64 12
     ; This division clobbers two of its fixed input registers on Intel.

--- a/filetests/regalloc/reload-208.cton
+++ b/filetests/regalloc/reload-208.cton
@@ -11,11 +11,11 @@ isa intel haswell
 ;
 ; The problem was the reload pass rewriting EBB arguments on "brnz v9, ebb3(v9)"
 
-function %pr208(i64 vmctx [%rdi]) native {
+function %pr208(i64 vmctx [%rdi]) system_v {
     gv0 = vmctx-8
     heap0 = static gv0, min 0, bound 0x5000, guard 0x0040_0000
-    sig0 = (i64 vmctx [%rdi]) -> i32 [%rax] native
-    sig1 = (i64 vmctx [%rdi], i32 [%rsi]) native
+    sig0 = (i64 vmctx [%rdi]) -> i32 [%rax] system_v
+    sig1 = (i64 vmctx [%rdi], i32 [%rsi]) system_v
     fn0 = sig0 u0:1
     fn1 = sig1 u0:3
 

--- a/filetests/regalloc/reload.cton
+++ b/filetests/regalloc/reload.cton
@@ -5,7 +5,7 @@ isa riscv enable_e
 
 ; Check that we can handle a function return value that got spilled.
 function %spill_return() -> i32 {
-    fn0 = function %foo() -> i32 native
+    fn0 = function %foo() -> i32 system_v
 
 ebb0:
     v0 = call fn0()

--- a/filetests/regalloc/schedule-moves.cton
+++ b/filetests/regalloc/schedule-moves.cton
@@ -1,7 +1,7 @@
 test regalloc
 isa intel haswell
 
-function %pr165() native {
+function %pr165() system_v {
 ebb0:
     v0 = iconst.i32 0x0102_0304
     v1 = iconst.i32 0x1102_0304
@@ -19,7 +19,7 @@ ebb0:
 
 ; Same as above, but use so many registers that spilling is required.
 ; Note: This is also a candidate for using xchg instructions.
-function %emergency_spill() native {
+function %emergency_spill() system_v {
 ebb0:
     v0 = iconst.i32 0x0102_0304
     v1 = iconst.i32 0x1102_0304

--- a/filetests/regalloc/spill-noregs.cton
+++ b/filetests/regalloc/spill-noregs.cton
@@ -13,7 +13,7 @@ isa intel
 ;
 ; The spiller was not releasing register pressure for dead EBB parameters.
 
-function %pr223(i32 [%rdi], i64 vmctx [%rsi]) -> i64 [%rax] native {
+function %pr223(i32 [%rdi], i64 vmctx [%rsi]) -> i64 [%rax] system_v {
 ebb0(v0: i32, v1: i64):
     v2 = iconst.i32 0
     v3 = iconst.i64 0

--- a/filetests/regalloc/spill.cton
+++ b/filetests/regalloc/spill.cton
@@ -93,7 +93,7 @@ ebb0(v0: i32):
 
 ; The same value used as indirect callee and argument.
 function %doubleuse_icall1(i32) {
-    sig0 = (i32) native
+    sig0 = (i32) system_v
 ebb0(v0: i32):
     ; not:copy
     call_indirect sig0, v0(v0)
@@ -102,7 +102,7 @@ ebb0(v0: i32):
 
 ; The same value used as indirect callee and two arguments.
 function %doubleuse_icall2(i32) {
-    sig0 = (i32, i32) native
+    sig0 = (i32, i32) system_v
 ebb0(v0: i32):
     ; check: $(c=$V) = copy v0
     call_indirect sig0, v0(v0, v0)

--- a/filetests/verifier/defs_dominates_uses.cton
+++ b/filetests/verifier/defs_dominates_uses.cton
@@ -2,14 +2,14 @@ test verifier
 
 ; Test verification that uses properly dominate defs.
 
-function %non_dominating(i32) -> i32 native {
+function %non_dominating(i32) -> i32 system_v {
 ebb0(v0: i32):
     v1 = iadd.i32 v2, v0   ; error: uses value from non-dominating
     v2 = iadd.i32 v1, v0
     return v2
 }
 
-function %inst_uses_its_own_values(i32) -> i32 native {
+function %inst_uses_its_own_values(i32) -> i32 system_v {
 ebb0(v0: i32):
     v1 = iadd.i32 v1, v0   ; error: uses value from itself
     return v1

--- a/lib/cretonne/src/ir/extfunc.rs
+++ b/lib/cretonne/src/ir/extfunc.rs
@@ -343,10 +343,11 @@ impl fmt::Display for ExtFuncData {
 /// determined by a `(TargetIsa, CallConv)` tuple.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CallConv {
-    /// The C calling convention.
+    /// The System V-style calling convention.
     ///
-    /// This is the native calling convention that a C compiler would use on the platform.
-    Native,
+    /// This is the System V-style calling convention that a C compiler would
+    /// use on many platforms.
+    SystemV,
 
     /// A JIT-compiled WebAssembly function in the SpiderMonkey VM.
     SpiderWASM,
@@ -356,7 +357,7 @@ impl fmt::Display for CallConv {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::CallConv::*;
         f.write_str(match *self {
-            Native => "native",
+            SystemV => "system_v",
             SpiderWASM => "spiderwasm",
         })
     }
@@ -368,7 +369,7 @@ impl FromStr for CallConv {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use self::CallConv::*;
         match s {
-            "native" => Ok(Native),
+            "system_v" => Ok(SystemV),
             "spiderwasm" => Ok(SpiderWASM),
             _ => Err(()),
         }
@@ -410,7 +411,7 @@ mod tests {
 
     #[test]
     fn call_conv() {
-        for &cc in &[CallConv::Native, CallConv::SpiderWASM] {
+        for &cc in &[CallConv::SystemV, CallConv::SpiderWASM] {
             assert_eq!(Ok(cc), cc.to_string().parse())
         }
     }

--- a/lib/cretonne/src/ir/function.rs
+++ b/lib/cretonne/src/ir/function.rs
@@ -86,7 +86,7 @@ impl Function {
 
     /// Clear all data structures in this function.
     pub fn clear(&mut self) {
-        self.signature.clear(ir::CallConv::Native);
+        self.signature.clear(ir::CallConv::SystemV);
         self.stack_slots.clear();
         self.global_vars.clear();
         self.heaps.clear();
@@ -99,9 +99,9 @@ impl Function {
         self.srclocs.clear();
     }
 
-    /// Create a new empty, anonymous function with a native calling convention.
+    /// Create a new empty, anonymous function with a SystemV calling convention.
     pub fn new() -> Self {
-        Self::with_name_signature(ExternalName::default(), Signature::new(CallConv::Native))
+        Self::with_name_signature(ExternalName::default(), Signature::new(CallConv::SystemV))
     }
 
     /// Creates a jump table in the function, to be used by `br_table` instructions.

--- a/lib/cretonne/src/isa/intel/abi.rs
+++ b/lib/cretonne/src/isa/intel/abi.rs
@@ -171,7 +171,7 @@ pub fn callee_saved_registers(flags: &shared_settings::Flags) -> &'static [RU] {
 
 pub fn prologue_epilogue(func: &mut ir::Function, isa: &TargetIsa) -> result::CtonResult {
     match func.signature.call_conv {
-        ir::CallConv::Native => native_prologue_epilogue(func, isa),
+        ir::CallConv::SystemV => system_v_prologue_epilogue(func, isa),
         ir::CallConv::SpiderWASM => spiderwasm_prologue_epilogue(func, isa),
     }
 }
@@ -194,7 +194,7 @@ pub fn spiderwasm_prologue_epilogue(
 }
 
 /// Insert a System V-compatible prologue and epilogue.
-pub fn native_prologue_epilogue(func: &mut ir::Function, isa: &TargetIsa) -> result::CtonResult {
+pub fn system_v_prologue_epilogue(func: &mut ir::Function, isa: &TargetIsa) -> result::CtonResult {
     // The original 32-bit x86 ELF ABI had a 4-byte aligned stack pointer, but
     // newer versions use a 16-byte aligned stack pointer.
     let stack_align = 16;
@@ -242,17 +242,17 @@ pub fn native_prologue_epilogue(func: &mut ir::Function, isa: &TargetIsa) -> res
     // Set up the cursor and insert the prologue
     let entry_ebb = func.layout.entry_block().expect("missing entry block");
     let mut pos = EncCursor::new(func, isa).at_first_insertion_point(entry_ebb);
-    insert_native_prologue(&mut pos, local_stack_size, csr_type, csrs);
+    insert_system_v_prologue(&mut pos, local_stack_size, csr_type, csrs);
 
     // Reset the cursor and insert the epilogue
     let mut pos = pos.at_position(CursorPosition::Nowhere);
-    insert_native_epilogues(&mut pos, local_stack_size, csr_type, csrs);
+    insert_system_v_epilogues(&mut pos, local_stack_size, csr_type, csrs);
 
     Ok(())
 }
 
 /// Insert the prologue for a given function.
-fn insert_native_prologue(
+fn insert_system_v_prologue(
     pos: &mut EncCursor,
     stack_size: i64,
     csr_type: ir::types::Type,
@@ -286,7 +286,7 @@ fn insert_native_prologue(
 }
 
 /// Find all `return` instructions and insert epilogues before them.
-fn insert_native_epilogues(
+fn insert_system_v_epilogues(
     pos: &mut EncCursor,
     stack_size: i64,
     csr_type: ir::types::Type,
@@ -296,14 +296,14 @@ fn insert_native_epilogues(
         pos.goto_last_inst(ebb);
         if let Some(inst) = pos.current_inst() {
             if pos.func.dfg[inst].opcode().is_return() {
-                insert_native_epilogue(inst, stack_size, pos, csr_type, csrs);
+                insert_system_v_epilogue(inst, stack_size, pos, csr_type, csrs);
             }
         }
     }
 }
 
 /// Insert an epilogue given a specific `return` instruction.
-fn insert_native_epilogue(
+fn insert_system_v_epilogue(
     inst: ir::Inst,
     stack_size: i64,
     pos: &mut EncCursor,

--- a/lib/cretonne/src/legalizer/libcall.rs
+++ b/lib/cretonne/src/legalizer/libcall.rs
@@ -44,8 +44,8 @@ fn find_funcref(libcall: ir::LibCall, func: &ir::Function) -> Option<ir::FuncRef
 
 /// Create a funcref for `libcall` with a signature matching `inst`.
 fn make_funcref(libcall: ir::LibCall, inst: ir::Inst, func: &mut ir::Function) -> ir::FuncRef {
-    // Start with a native calling convention. We'll give the ISA a chance to change it.
-    let mut sig = ir::Signature::new(ir::CallConv::Native);
+    // Start with a system_v calling convention. We'll give the ISA a chance to change it.
+    let mut sig = ir::Signature::new(ir::CallConv::SystemV);
     for &v in func.dfg.inst_args(inst) {
         sig.params.push(ir::AbiParam::new(func.dfg.value_type(v)));
     }

--- a/lib/cretonne/src/write.rs
+++ b/lib/cretonne/src/write.rs
@@ -465,34 +465,34 @@ mod tests {
     #[test]
     fn basic() {
         let mut f = Function::new();
-        assert_eq!(f.to_string(), "function u0:0() native {\n}\n");
+        assert_eq!(f.to_string(), "function u0:0() system_v {\n}\n");
 
         f.name = ExternalName::testcase("foo");
-        assert_eq!(f.to_string(), "function %foo() native {\n}\n");
+        assert_eq!(f.to_string(), "function %foo() system_v {\n}\n");
 
         f.create_stack_slot(StackSlotData::new(StackSlotKind::ExplicitSlot, 4));
         assert_eq!(
             f.to_string(),
-            "function %foo() native {\n    ss0 = explicit_slot 4\n}\n"
+            "function %foo() system_v {\n    ss0 = explicit_slot 4\n}\n"
         );
 
         let ebb = f.dfg.make_ebb();
         f.layout.append_ebb(ebb);
         assert_eq!(
             f.to_string(),
-            "function %foo() native {\n    ss0 = explicit_slot 4\n\nebb0:\n}\n"
+            "function %foo() system_v {\n    ss0 = explicit_slot 4\n\nebb0:\n}\n"
         );
 
         f.dfg.append_ebb_param(ebb, types::I8);
         assert_eq!(
             f.to_string(),
-            "function %foo() native {\n    ss0 = explicit_slot 4\n\nebb0(v0: i8):\n}\n"
+            "function %foo() system_v {\n    ss0 = explicit_slot 4\n\nebb0(v0: i8):\n}\n"
         );
 
         f.dfg.append_ebb_param(ebb, types::F32.by(4).unwrap());
         assert_eq!(
             f.to_string(),
-            "function %foo() native {\n    ss0 = explicit_slot 4\n\nebb0(v0: i8, v1: f32x4):\n}\n"
+            "function %foo() system_v {\n    ss0 = explicit_slot 4\n\nebb0(v0: i8, v1: f32x4):\n}\n"
         );
     }
 }

--- a/lib/frontend/src/frontend.rs
+++ b/lib/frontend/src/frontend.rs
@@ -600,7 +600,7 @@ mod tests {
     use Variable;
 
     fn sample_function(lazy_seal: bool) {
-        let mut sig = Signature::new(CallConv::Native);
+        let mut sig = Signature::new(CallConv::SystemV);
         sig.returns.push(AbiParam::new(I32));
         sig.params.push(AbiParam::new(I32));
 

--- a/lib/frontend/src/lib.rs
+++ b/lib/frontend/src/lib.rs
@@ -43,7 +43,7 @@
 //! use cretonne::verifier::verify_function;
 //!
 //! fn main() {
-//!     let mut sig = Signature::new(CallConv::Native);
+//!     let mut sig = Signature::new(CallConv::SystemV);
 //!     sig.returns.push(AbiParam::new(I32));
 //!     sig.params.push(AbiParam::new(I32));
 //!     let mut fn_builder_ctx = FunctionBuilderContext::<Variable>::new();

--- a/lib/wasm/src/sections_translator.rs
+++ b/lib/wasm/src/sections_translator.rs
@@ -36,7 +36,7 @@ pub fn parse_function_signatures(
                                               ref params,
                                               ref returns,
                                           }) => {
-                let mut sig = Signature::new(CallConv::Native);
+                let mut sig = Signature::new(CallConv::SystemV);
                 sig.params.extend(params.iter().map(|ty| {
                     let cret_arg: cretonne::ir::Type = type_to_type(ty).expect(
                         "only numeric types are supported in function signatures",


### PR DESCRIPTION
To keep cross-compiling straightforward, Cretonne shouldn't have any
behavior that depends on the host. This renames the "Native" calling
convention to "SystemV", which has a defined meaning for each target,
so that it's clear that the calling convention doesn't change
depending on what host Cretonne is running on.