### PR TITLE
Fix broken build on no_std.

### DIFF
--- a/lib/codegen/src/lib.rs
+++ b/lib/codegen/src/lib.rs
@@ -119,6 +119,6 @@ mod std {
 
         pub use self::hashmap_core::map as hash_map;
         pub use self::hashmap_core::{HashMap, HashSet};
-        pub use alloc::BTreeSet;
+        pub use alloc::collections::BTreeSet;
     }
 }

--- a/lib/native/Cargo.toml
+++ b/lib/native/Cargo.toml
@@ -12,7 +12,7 @@ cretonne-codegen = { path = "../codegen", version = "0.13.0", default-features =
 target-lexicon = { version = "0.0.2", default-features = false }
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
-raw-cpuid = "4"
+raw-cpuid = "3.1.0"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This does two things. First, updates the use of the alloc crate to the latest nightly version. Secondly, it downgrades the use of the cpuid crate to a version that doesn't have issues compiling in a custom environment.