### PR TITLE
Teach LICM to edit branch tables

### DIFF
--- a/cranelift-codegen/src/ir/instructions.rs
+++ b/cranelift-codegen/src/ir/instructions.rs
@@ -250,7 +250,7 @@ impl InstructionData {
                 ref mut destination,
                 ..
             } => Some(destination),
-            InstructionData::BranchTable { .. } => None,
+            InstructionData::BranchTable { .. } | InstructionData::IndirectJump { .. } => None,
             _ => {
                 debug_assert!(!self.opcode().is_branch());
                 None

--- a/filetests/licm/br_table.clif
+++ b/filetests/licm/br_table.clif
@@ -1,0 +1,37 @@
+test licm
+target x86_64
+
+function %br(i64) -> i32 {
+    jt0 = jump_table [ebb2, ebb3]
+
+ebb0(v0: i64):
+    br_table v0, ebb1, jt0
+ebb1:
+    v1 = iconst.i32 0
+    return v1
+ebb2:
+    v2 = iconst.i32 0
+    jump ebb2
+ebb3:
+    trap user65535
+}
+; sameln: function %br
+; nextln:    jt0 = jump_table [ebb4, ebb3]
+; nextln: 
+; nextln: ebb0(v0: i64):
+; nextln:    br_table v0, ebb1, jt0
+; nextln: 
+; nextln: ebb1:
+; nextln:    v1 = iconst.i32 0
+; nextln:    return v1
+; nextln: 
+; nextln: ebb4:
+; nextln:    v2 = iconst.i32 0
+; nextln:    jump ebb2
+; nextln: 
+; nextln: ebb2:
+; nextln:    jump ebb2
+; nextln: 
+; nextln: ebb3:
+; nextln:    trap user65535
+; nextln: }

--- a/filetests/licm/br_table.clif
+++ b/filetests/licm/br_table.clif
@@ -5,21 +5,30 @@ function %br(i64) -> i32 {
     jt0 = jump_table [ebb2, ebb3]
 
 ebb0(v0: i64):
-    br_table v0, ebb1, jt0
+[RexOp1jt_base#808d]   v4 = jump_table_base.i64 jt0
+[RexOp1jt_entry#8063]  v5 = jump_table_entry.i64 v0, v4, 4, jt0
+                       v6 = iadd v4, v5
+[Op1indirect_jmp#40ff] indirect_jump_table_br v6, jt0
+
 ebb1:
-    v1 = iconst.i32 0
-    return v1
+                       v1 = iconst.i32 0
+[Op1ret#c3]            return v1
+
 ebb2:
-    v2 = iconst.i32 0
-    jump ebb2
+                       v2 = iconst.i32 0
+[Op1jmpb#eb]           jump ebb2
+    
 ebb3:
-    trap user65535
+[Op2trap#40b]          trap user65535
 }
 ; sameln: function %br
-; nextln:    jt0 = jump_table [ebb4, ebb3]
+; nextln:     jt0 = jump_table [ebb4, ebb3]
 ; nextln: 
 ; nextln: ebb0(v0: i64):
-; nextln:    br_table v0, ebb1, jt0
+; nextln:    v4 = jump_table_base.i64 jt0
+; nextln:    v5 = jump_table_entry.i64 v0, v4, 4, jt0
+; nextln:    v6 = iadd v4, v5
+; nextln:    indirect_jump_table_br v6, jt0
 ; nextln: 
 ; nextln: ebb1:
 ; nextln:    v1 = iconst.i32 0

--- a/filetests/licm/br_table.clif
+++ b/filetests/licm/br_table.clif
@@ -22,13 +22,14 @@ ebb3:
 [Op2trap#40b]          trap user65535
 }
 ; sameln: function %br
-; nextln:     jt0 = jump_table [ebb4, ebb3]
+; nextln:     jt0 = jump_table [ebb2, ebb3]
+; nextln:     jt1 = jump_table [ebb4, ebb3]
 ; nextln: 
 ; nextln: ebb0(v0: i64):
-; nextln:    v4 = jump_table_base.i64 jt0
-; nextln:    v5 = jump_table_entry.i64 v0, v4, 4, jt0
+; nextln:    v4 = jump_table_base.i64 jt1
+; nextln:    v5 = jump_table_entry.i64 v0, v4, 4, jt1
 ; nextln:    v6 = iadd v4, v5
-; nextln:    indirect_jump_table_br v6, jt0
+; nextln:    indirect_jump_table_br v6, jt1
 ; nextln: 
 ; nextln: ebb1:
 ; nextln:    v1 = iconst.i32 0

--- a/filetests/licm/br_table_complex.clif
+++ b/filetests/licm/br_table_complex.clif
@@ -1,0 +1,51 @@
+test licm
+target x86_64
+
+function %br_complex(i64, i64) {
+    jt0 = jump_table [ebb2, ebb3]
+
+ebb0(v0: i64, v1: i64):
+[RexOp1jt_base#808d]   v4 = jump_table_base.i64 jt0
+[RexOp1jt_entry#8063]  v5 = jump_table_entry.i64 v0, v4, 4, jt0
+                       v6 = iadd v4, v5
+[Op1indirect_jmp#40ff] indirect_jump_table_br v6, jt0
+
+ebb1:
+[Op1ret#c3]            return
+
+ebb2:
+                       v2 = iconst.i32 0
+[RexOp1jt_entry#8063]  v7 = jump_table_entry.i64 v1, v4, 4, jt0
+                       v8 = iadd v4, v7
+[Op1indirect_jmp#40ff] indirect_jump_table_br v8, jt0
+
+
+ebb3:
+[Op2trap#40b]          trap user65535
+}
+
+; sameln: function %br_complex
+; nextln:     jt0 = jump_table [ebb2, ebb3]
+; nextln:     jt1 = jump_table [ebb4, ebb3]
+; nextln: 
+; nextln: ebb0(v0: i64, v1: i64):
+; nextln:    v4 = jump_table_base.i64 jt0
+; nextln:    v5 = jump_table_entry.i64 v0, v4, 4, jt0
+; nextln:    v6 = iadd v4, v5
+; nextln:    indirect_jump_table_br v6, jt1
+; nextln: 
+; nextln: ebb1:
+; nextln:    return
+; nextln: 
+; nextln: ebb4:
+; nextln:    v2 = iconst.i32 0
+; nextln:    v7 = jump_table_entry.i64 v1, v4, 4, jt0
+; nextln:    v8 = iadd.i64 v4, v7
+; nextln:    jump ebb2
+; nextln: 
+; nextln: ebb2:
+; nextln:    indirect_jump_table_br.i64 v8, jt0
+; nextln: 
+; nextln: ebb3:
+; nextln:    trap user65535
+; nextln: }

--- a/filetests/licm/br_table_complex.clif
+++ b/filetests/licm/br_table_complex.clif
@@ -15,9 +15,10 @@ ebb1:
 
 ebb2:
                        v2 = iconst.i32 0
-[RexOp1jt_entry#8063]  v7 = jump_table_entry.i64 v1, v4, 4, jt0
-                       v8 = iadd v4, v7
-[Op1indirect_jmp#40ff] indirect_jump_table_br v8, jt0
+[RexOp1jt_base#808d]   v7 = jump_table_base.i64 jt0
+[RexOp1jt_entry#8063]  v8 = jump_table_entry.i64 v1, v4, 4, jt0
+                       v9 = iadd v7, v8
+[Op1indirect_jmp#40ff] indirect_jump_table_br v9, jt0
 
 
 ebb3:
@@ -29,8 +30,8 @@ ebb3:
 ; nextln:     jt1 = jump_table [ebb4, ebb3]
 ; nextln: 
 ; nextln: ebb0(v0: i64, v1: i64):
-; nextln:    v4 = jump_table_base.i64 jt0
-; nextln:    v5 = jump_table_entry.i64 v0, v4, 4, jt0
+; nextln:    v4 = jump_table_base.i64 jt1
+; nextln:    v5 = jump_table_entry.i64 v0, v4, 4, jt1
 ; nextln:    v6 = iadd v4, v5
 ; nextln:    indirect_jump_table_br v6, jt1
 ; nextln: 
@@ -39,12 +40,13 @@ ebb3:
 ; nextln: 
 ; nextln: ebb4:
 ; nextln:    v2 = iconst.i32 0
-; nextln:    v7 = jump_table_entry.i64 v1, v4, 4, jt0
-; nextln:    v8 = iadd.i64 v4, v7
+; nextln:    v7 = jump_table_base.i64 jt0
+; nextln:    v8 = jump_table_entry.i64 v1, v4, 4, jt0
+; nextln:    v9 = iadd v7, v8
 ; nextln:    jump ebb2
 ; nextln: 
 ; nextln: ebb2:
-; nextln:    indirect_jump_table_br.i64 v8, jt0
+; nextln:    indirect_jump_table_br.i64 v9, jt0
 ; nextln: 
 ; nextln: ebb3:
 ; nextln:    trap user65535


### PR DESCRIPTION
This is meant to fix #732.

It addresses the surface issue of the different behavior between `branch_destination` and `branch_destination_mut`. (I think I did that, sorry.) But it also teaches LICM how to update branch tables.