### PR TITLE
[WIP] Delay slot filler framework

### DIFF
--- a/cranelift-codegen/meta-python/base/instructions.py
+++ b/cranelift-codegen/meta-python/base/instructions.py
@@ -59,7 +59,8 @@ jump = Instruction(
         EBB arguments. The number and types of arguments must match the
         destination EBB.
         """,
-        ins=(EBB, args), is_branch=True, is_terminator=True)
+        ins=(EBB, args), is_branch=True, is_terminator=True,
+        has_delay_slot=True)
 
 fallthrough = Instruction(
         'fallthrough', r"""
@@ -72,7 +73,8 @@ fallthrough = Instruction(
         relaxation pass. There is no reason to use this instruction outside
         that pass.
         """,
-        ins=(EBB, args), is_branch=True, is_terminator=True)
+        ins=(EBB, args), is_branch=True, is_terminator=True,
+        has_delay_slot=True)
 
 brz = Instruction(
         'brz', r"""
@@ -81,7 +83,7 @@ brz = Instruction(
         If ``c`` is a :type:`b1` value, take the branch when ``c`` is false. If
         ``c`` is an integer value, take the branch when ``c = 0``.
         """,
-        ins=(c, EBB, args), is_branch=True)
+        ins=(c, EBB, args), is_branch=True, has_delay_slot=True)
 
 brnz = Instruction(
         'brnz', r"""
@@ -90,7 +92,7 @@ brnz = Instruction(
         If ``c`` is a :type:`b1` value, take the branch when ``c`` is true. If
         ``c`` is an integer value, take the branch when ``c != 0``.
         """,
-        ins=(c, EBB, args), is_branch=True)
+        ins=(c, EBB, args), is_branch=True, has_delay_slot=True)
 
 br_icmp = Instruction(
         'br_icmp', r"""
@@ -110,7 +112,7 @@ br_icmp = Instruction(
         implement all or some of the condition codes. The instruction can also
         be used to represent *macro-op fusion* on architectures like Intel's.
         """,
-        ins=(Cond, x, y, EBB, args), is_branch=True)
+        ins=(Cond, x, y, EBB, args), is_branch=True, has_delay_slot=True)
 
 f = Operand('f', iflags)
 
@@ -118,7 +120,7 @@ brif = Instruction(
         'brif', r"""
         Branch when condition is true in integer CPU flags.
         """,
-        ins=(Cond, f, EBB, args), is_branch=True)
+        ins=(Cond, f, EBB, args), is_branch=True, has_delay_slot=True)
 
 Cond = Operand('Cond', floatcc)
 f = Operand('f', fflags)
@@ -127,7 +129,7 @@ brff = Instruction(
         'brff', r"""
         Branch when condition is true in floating point CPU flags.
         """,
-        ins=(Cond, f, EBB, args), is_branch=True)
+        ins=(Cond, f, EBB, args), is_branch=True, has_delay_slot=True)
 
 x = Operand('x', iB, doc='index into jump table')
 Entry = TypeVar('Entry', 'A scalar integer type', ints=True)
@@ -150,7 +152,8 @@ br_table = Instruction(
         function in a dynamic library, that will typically use
         ``call_indirect``.
         """,
-        ins=(x, EBB, JT), is_branch=True, is_terminator=True)
+        ins=(x, EBB, JT), is_branch=True, is_terminator=True,
+        has_delay_slot=True)
 
 Size = Operand('Size', uimm8, 'Size in bytes')
 jump_table_entry = Instruction(
@@ -185,7 +188,8 @@ indirect_jump_table_br = Instruction(
     with the ``jump_table_entry`` instruction.
     """,
     ins=(addr, JT),
-    is_branch=True, is_indirect_branch=True, is_terminator=True)
+    is_branch=True, is_indirect_branch=True, is_terminator=True,
+    has_delay_slot=True)
 
 debugtrap = Instruction('debugtrap', r"""
     Encodes an assembly debug trap.
@@ -242,7 +246,7 @@ x_return = Instruction(
         provided return values. The list of return values must match the
         function signature's return types.
         """,
-        ins=rvals, is_return=True, is_terminator=True)
+        ins=rvals, is_return=True, is_terminator=True, has_delay_slot=True)
 
 fallthrough_return = Instruction(
         'fallthrough_return', r"""
@@ -267,7 +271,7 @@ call = Instruction(
         Call a function which has been declared in the preamble. The argument
         types must match the function's signature.
         """,
-        ins=(FN, args), outs=rvals, is_call=True)
+        ins=(FN, args), outs=rvals, is_call=True, has_delay_slot=True)
 
 SIG = Operand('SIG', entities.sig_ref, doc='function signature')
 callee = Operand('callee', iAddr, doc='address of function to call')
@@ -284,7 +288,7 @@ call_indirect = Instruction(
         :inst:`table_addr` and :inst:`load` are used to obtain a native address
         from a table.
         """,
-        ins=(SIG, callee, args), outs=rvals, is_call=True)
+        ins=(SIG, callee, args), outs=rvals, is_call=True, has_delay_slot=True)
 
 func_addr = Instruction(
         'func_addr', r"""

--- a/cranelift-codegen/meta-python/cdsl/instructions.py
+++ b/cranelift-codegen/meta-python/cdsl/instructions.py
@@ -97,6 +97,8 @@ class Instruction(object):
     :param can_trap: This instruction can trap.
     :param can_load: This instruction can load from memory.
     :param can_store: This instruction can store to memory.
+    :param has_delay_slot: This instruction has a delay slot. Currently only a
+                           single branch delay slot is supported.
     :param other_side_effects: Instruction has other side effects.
     """
 
@@ -114,6 +116,7 @@ class Instruction(object):
             'can_load': 'Can this instruction read from memory?',
             'can_store': 'Can this instruction write to memory?',
             'can_trap': 'Can this instruction cause a trap?',
+            'has_delay_slot': 'Does this instruction have a delay slot?',
             'other_side_effects':
             'Does this instruction have other side effects besides can_*',
             'writes_cpu_flags': 'Does this instruction write to CPU flags?',

--- a/cranelift-codegen/meta/src/cdsl/inst.rs
+++ b/cranelift-codegen/meta/src/cdsl/inst.rs
@@ -84,6 +84,8 @@ pub struct Instruction {
     pub can_store: bool,
     /// Can this instruction cause a trap?
     pub can_trap: bool,
+    /// Does this instruction have a delay slot?
+    pub has_delay_slot: bool,
     /// Does this instruction have other side effects besides can_* flags?
     pub other_side_effects: bool,
     /// Does this instruction write to CPU flags?
@@ -157,6 +159,7 @@ pub struct InstructionBuilder {
     can_load: bool,
     can_store: bool,
     can_trap: bool,
+    has_delay_slot: bool,
     other_side_effects: bool,
 }
 
@@ -178,6 +181,7 @@ impl InstructionBuilder {
             can_load: false,
             can_store: false,
             can_trap: false,
+            has_delay_slot: false,
             other_side_effects: false,
         }
     }
@@ -232,6 +236,10 @@ impl InstructionBuilder {
     }
     pub fn can_trap(mut self, val: bool) -> Self {
         self.can_trap = val;
+        self
+    }
+    pub fn has_delay_slot(mut self, val: bool) -> Self {
+        self.has_delay_slot = val;
         self
     }
     pub fn other_side_effects(mut self, val: bool) -> Self {
@@ -292,6 +300,7 @@ impl InstructionBuilder {
             can_load: self.can_load,
             can_store: self.can_store,
             can_trap: self.can_trap,
+            has_delay_slot: self.has_delay_slot,
             other_side_effects: self.other_side_effects,
             writes_cpu_flags,
         }

--- a/cranelift-codegen/meta/src/gen_inst.rs
+++ b/cranelift-codegen/meta/src/gen_inst.rs
@@ -517,6 +517,13 @@ fn gen_opcodes<'a>(
         );
         gen_bool_accessor(
             igroups,
+            |inst| inst.has_delay_slot,
+            "has_delay_slot",
+            "Does this instruction have a delay slot?",
+            fmt,
+        );
+        gen_bool_accessor(
+            igroups,
             |inst| inst.other_side_effects,
             "other_side_effects",
             "Does this instruction have other side effects besides can_* flags?",

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -152,6 +152,7 @@ pub fn define(
         .operands_in(vec![EBB, args])
         .is_terminator(true)
         .is_branch(true)
+        .has_delay_slot(true)
         .finish(format_registry),
     );
 
@@ -187,6 +188,7 @@ pub fn define(
         )
         .operands_in(vec![c, EBB, args])
         .is_branch(true)
+        .has_delay_slot(true)
         .finish(format_registry),
     );
 
@@ -202,6 +204,7 @@ pub fn define(
         )
         .operands_in(vec![c, EBB, args])
         .is_branch(true)
+        .has_delay_slot(true)
         .finish(format_registry),
     );
 
@@ -228,6 +231,7 @@ pub fn define(
         )
         .operands_in(vec![Cond, x, y, EBB, args])
         .is_branch(true)
+        .has_delay_slot(true)
         .finish(format_registry),
     );
 
@@ -242,6 +246,7 @@ pub fn define(
         )
         .operands_in(vec![Cond, f, EBB, args])
         .is_branch(true)
+        .has_delay_slot(true)
         .finish(format_registry),
     );
 
@@ -257,6 +262,7 @@ pub fn define(
         )
         .operands_in(vec![Cond, f, EBB, args])
         .is_branch(true)
+        .has_delay_slot(true)
         .finish(format_registry),
     );
 
@@ -294,6 +300,7 @@ pub fn define(
         .operands_in(vec![x, EBB, JT])
         .is_terminator(true)
         .is_branch(true)
+        .has_delay_slot(true)
         .finish(format_registry),
     );
 
@@ -349,6 +356,7 @@ pub fn define(
         .is_indirect_branch(true)
         .is_terminator(true)
         .is_branch(true)
+        .has_delay_slot(true)
         .finish(format_registry),
     );
 
@@ -454,6 +462,7 @@ pub fn define(
         .operands_in(vec![rvals])
         .is_return(true)
         .is_terminator(true)
+        .has_delay_slot(true)
         .finish(format_registry),
     );
 
@@ -494,6 +503,7 @@ pub fn define(
         .operands_in(vec![FN, args])
         .operands_out(vec![rvals])
         .is_call(true)
+        .has_delay_slot(true)
         .finish(format_registry),
     );
 
@@ -518,6 +528,7 @@ pub fn define(
         .operands_in(vec![SIG, callee, args])
         .operands_out(vec![rvals])
         .is_call(true)
+        .has_delay_slot(true)
         .finish(format_registry),
     );
 

--- a/cranelift-codegen/src/binemit/delay_slot_filler.rs
+++ b/cranelift-codegen/src/binemit/delay_slot_filler.rs
@@ -1,0 +1,71 @@
+//! Delay slot filling.
+
+use crate::binemit::CodeOffset;
+use crate::cursor::{Cursor, FuncCursor};
+use crate::ir::{Function, InstructionData, Opcode};
+use crate::isa::{EncInfo, TargetIsa};
+use crate::iterators::IteratorExtras;
+use crate::regalloc::RegDiversions;
+use crate::timing;
+use crate::CodegenResult;
+use log::debug;
+
+/// Fill delay slots and calculate code size.
+pub fn fill_delay_slots(func: &mut Function, isa: &TargetIsa) -> CodegenResult<CodeOffset> {
+    let _tt = timing::fill_delay_slots();
+
+    let encinfo = isa.encoding_info();
+
+    // Clear all offsets so we can recognize EBBs that haven't been visited yet.
+    func.offsets.clear();
+    func.offsets.resize(func.dfg.num_ebbs());
+
+    let mut offset = 0;
+    let mut divert = RegDiversions::new();
+
+    // Fill the delay slots.
+    {
+        // Visit all instructions in layout order.
+        let mut cur = FuncCursor::new(func);
+        while let Some(ebb) = cur.next_ebb() {
+            divert.clear();
+
+            while let Some(inst) = cur.next_inst() {
+                divert.apply(&cur.func.dfg[inst]);
+
+                let enc = cur.func.encodings[inst];
+
+                if cur.func.dfg[inst].opcode().has_delay_slot() {
+                    isa.fill_delay_slot_for_inst(&mut cur, &divert, &encinfo);
+                    continue;
+                }
+
+                offset += encinfo.byte_size(enc, inst, &divert, &cur.func);
+            }
+        }
+    }
+
+    // Fix up the offsets.
+    {
+        let mut cur = FuncCursor::new(func);
+        offset = 0;
+        while let Some(ebb) = cur.next_ebb() {
+            divert.clear();
+            cur.func.offsets[ebb] = offset;
+            while let Some(inst) = cur.next_inst() {
+                divert.apply(&cur.func.dfg[inst]);
+                let enc = cur.func.encodings[inst];
+                offset += encinfo.byte_size(enc, inst, &divert, &cur.func);
+            }
+        }
+    }
+
+    for (jt, jt_data) in func.jump_tables.iter() {
+        func.jt_offsets[jt] = offset;
+        // TODO: this should be computed based on the min size needed to hold
+        //        the furthest branch.
+        offset += jt_data.len() as u32 * 4;
+    }
+
+    Ok(offset)
+}

--- a/cranelift-codegen/src/binemit/mod.rs
+++ b/cranelift-codegen/src/binemit/mod.rs
@@ -3,10 +3,12 @@
 //! The `binemit` module contains code for translating Cranelift's intermediate representation into
 //! binary machine code.
 
+mod delay_slot_filler;
 mod memorysink;
 mod relaxation;
 mod shrink;
 
+pub use self::delay_slot_filler::fill_delay_slots;
 pub use self::memorysink::{MemoryCodeSink, NullTrapSink, RelocSink, TrapSink};
 pub use self::relaxation::relax_branches;
 pub use self::shrink::shrink_instructions;

--- a/cranelift-codegen/src/context.rs
+++ b/cranelift-codegen/src/context.rs
@@ -342,8 +342,9 @@ impl Context {
     /// Fill delay slots if applicable and return the code size after processing.
     pub fn fill_delay_slots(&mut self, isa: &TargetIsa) -> CodegenResult<CodeOffset> {
         let code_size = fill_delay_slots(&mut self.func, isa)?;
-        self.verify_if(isa)?;
-        self.verify_locations_if(isa)?;
+        // TODO teach verifier about delay slots
+        // self.verify_if(isa)?;
+        // self.verify_locations_if(isa)?;
         Ok(code_size)
     }
 }

--- a/cranelift-codegen/src/isa/mod.rs
+++ b/cranelift-codegen/src/isa/mod.rs
@@ -55,6 +55,7 @@ pub use crate::isa::registers::{regs_overlap, RegClass, RegClassIndex, RegInfo, 
 pub use crate::isa::stack::{StackBase, StackBaseMask, StackRef};
 
 use crate::binemit;
+use crate::cursor;
 use crate::flowgraph;
 use crate::ir;
 use crate::isa::enc_tables::Encodings;
@@ -252,6 +253,11 @@ pub trait TargetIsa: fmt::Display + Sync {
         false
     }
 
+    /// Does this ISA implement architectural delay slots?
+    fn has_delay_slot(&self) -> bool {
+        false
+    }
+
     /// Get a data structure describing the registers in this ISA.
     fn register_info(&self) -> RegInfo;
 
@@ -372,4 +378,14 @@ pub trait TargetIsa: fmt::Display + Sync {
 
     /// Emit a whole function into memory.
     fn emit_function_to_memory(&self, func: &ir::Function, sink: &mut binemit::MemoryCodeSink);
+
+    /// Fill delay slot for a single instruction.
+    fn fill_delay_slot_for_inst(
+        &self,
+        cur: &mut cursor::FuncCursor,
+        divert: &regalloc::RegDiversions,
+        encinfo: &EncInfo,
+    ) {
+        unimplemented!();
+    }
 }

--- a/cranelift-codegen/src/timing.rs
+++ b/cranelift-codegen/src/timing.rs
@@ -73,6 +73,7 @@ define_passes! {
     prologue_epilogue: "Prologue/epilogue insertion",
     shrink_instructions: "Instruction encoding shrinking",
     relax_branches: "Branch relaxation",
+    fill_delay_slots: "Delay slot filling",
     binemit: "Binary machine code emission",
     layout_renumber: "Layout full renumbering",
 


### PR DESCRIPTION
Ripped out from the ongoing MIPS port for earlier review.

Some outstanding questions:

* [ ] How to tag instructions moved into delay slots as such, for verifier use?
* [ ] Should the `has_delay_slot` flag be moved into encinfo realm? Seems a little more work to do, but I'm willing to because delay slots are inherently ISA-specific.

Also some comments are not adjusted after copy-pasting... will fix these afterwards.

Closes #728.