### PR TITLE
Add register-specific affinities and use them for ABI register parameters

### DIFF
--- a/cranelift-codegen/meta/src/gen_encodings.rs
+++ b/cranelift-codegen/meta/src/gen_encodings.rs
@@ -307,7 +307,7 @@ fn emit_operand_constraints(
                         if let Some(tied_input) = tied_operands.get(&n) {
                             fmtln!(fmt, "kind: ConstraintKind::Tied({}),", tied_input);
                         } else {
-                            fmt.line("kind: ConstraintKind::Reg,");
+                            fmt.line("kind: ConstraintKind::RegClass,");
                         }
                         fmtln!(
                             fmt,

--- a/cranelift-codegen/src/isa/constraints.rs
+++ b/cranelift-codegen/src/isa/constraints.rs
@@ -30,7 +30,7 @@ impl OperandConstraint {
     /// counterpart operand has the same value location.
     pub fn satisfied(&self, loc: ValueLoc) -> bool {
         match self.kind {
-            ConstraintKind::Reg | ConstraintKind::Tied(_) => {
+            ConstraintKind::RegClass | ConstraintKind::Tied(_) => {
                 if let ValueLoc::Reg(reg) = loc {
                     self.regclass.contains(reg)
                 } else {
@@ -55,7 +55,7 @@ impl OperandConstraint {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum ConstraintKind {
     /// This operand or result must be a register from the given register class.
-    Reg,
+    RegClass,
 
     /// This operand or result must be a fixed register.
     ///

--- a/cranelift-codegen/src/isa/registers.rs
+++ b/cranelift-codegen/src/isa/registers.rs
@@ -288,6 +288,15 @@ impl RegInfo {
         self.banks.iter().find(|b| b.contains(regunit))
     }
 
+    /// Get the top register class holding `regunit`.
+    pub fn toprc_containing_regunit(&self, regunit: RegUnit) -> RegClass {
+        let bank = self.bank_containing_regunit(regunit).unwrap();
+        self.classes[bank.first_toprc..(bank.first_toprc + bank.num_toprcs)]
+            .iter()
+            .find(|&rc| rc.contains(regunit))
+            .expect("reg unit should be in a toprc")
+    }
+
     /// Try to parse a regunit name. The name is not expected to begin with `%`.
     pub fn parse_regunit(&self, name: &str) -> Option<RegUnit> {
         self.banks

--- a/cranelift-codegen/src/regalloc/affinity.rs
+++ b/cranelift-codegen/src/regalloc/affinity.rs
@@ -9,7 +9,9 @@
 //! larger register class instead.
 
 use crate::ir::{AbiParam, ArgumentLoc};
-use crate::isa::{ConstraintKind, OperandConstraint, RegClassIndex, RegInfo, TargetIsa};
+use crate::isa::{
+    ConstraintKind, OperandConstraint, RegClass, RegClassIndex, RegInfo, RegUnit, TargetIsa,
+};
 use core::fmt;
 
 /// Preferred register allocation for an SSA value.
@@ -25,7 +27,10 @@ pub enum Affinity {
     Stack,
 
     /// This value prefers a register from the given register class.
-    Reg(RegClassIndex),
+    RegClass(RegClassIndex),
+
+    /// This value prefers a specific register unit
+    RegUnit(RegUnit),
 }
 
 impl Default for Affinity {
@@ -43,7 +48,7 @@ impl Affinity {
         if constraint.kind == ConstraintKind::Stack {
             Self::Stack
         } else {
-            Self::Reg(constraint.regclass.into())
+            Self::RegClass(constraint.regclass.into())
         }
     }
 
@@ -51,7 +56,7 @@ impl Affinity {
     pub fn abi(arg: &AbiParam, isa: &dyn TargetIsa) -> Self {
         match arg.location {
             ArgumentLoc::Unassigned => Self::Unassigned,
-            ArgumentLoc::Reg(_) => Self::Reg(isa.regclass_for_abi_type(arg.value_type).into()),
+            ArgumentLoc::Reg(_) => Self::RegClass(isa.regclass_for_abi_type(arg.value_type).into()),
             ArgumentLoc::Stack(_) => Self::Stack,
         }
     }
@@ -67,7 +72,7 @@ impl Affinity {
     /// Is this the `Reg` affinity?
     pub fn is_reg(self) -> bool {
         match self {
-            Self::Reg(_) => true,
+            Self::RegUnit(_) | Self::RegClass(_) => true,
             _ => false,
         }
     }
@@ -80,6 +85,22 @@ impl Affinity {
         }
     }
 
+    pub fn rc_in(&self, reginfo: &RegInfo) -> Option<RegClass> {
+        match self {
+            Affinity::RegUnit(reg) => Some(reginfo.toprc_containing_regunit(*reg)),
+            Affinity::RegClass(rci) => Some(reginfo.rc(*rci)),
+            _ => None,
+        }
+    }
+
+    pub fn toprc_in(&self, reginfo: &RegInfo) -> Option<RegClass> {
+        match self {
+            Affinity::RegUnit(reg) => Some(reginfo.toprc_containing_regunit(*reg)),
+            Affinity::RegClass(rci) => Some(reginfo.toprc(*rci)),
+            _ => None,
+        }
+    }
+
     /// Merge an operand constraint into this affinity.
     ///
     /// Note that this does not guarantee that the register allocator will pick a register that
@@ -87,18 +108,63 @@ impl Affinity {
     pub fn merge(&mut self, constraint: &OperandConstraint, reginfo: &RegInfo) {
         match *self {
             Self::Unassigned => *self = Self::new(constraint),
-            Self::Reg(rc) => {
+            Self::RegClass(rc) => {
                 // If the preferred register class is a subclass of the constraint, there's no need
                 // to change anything.
                 if constraint.kind != ConstraintKind::Stack && !constraint.regclass.has_subclass(rc)
                 {
                     // If the register classes overlap, try to shrink our preferred register class.
                     if let Some(subclass) = constraint.regclass.intersect_index(reginfo.rc(rc)) {
-                        *self = Self::Reg(subclass);
+                        *self = Self::RegClass(subclass);
                     }
                 }
             }
+            // Either the constraint is a stack constraint, and we would just keep this affinity,
+            // or it's a register constraint. If it's a register constraint, it's either the same,
+            // and we wouldn't change the affinity, or it's a different constraint, which has no
+            // intersection with this register, and wouldn't change the affinity.
+            //
+            // In all cases, we wouldn't change the affinity.
+            Self::RegUnit(_) => {}
             Self::Stack => {}
+        }
+    }
+
+    /// Compute the maximal intersection between this affinity and some other affinity.
+    ///
+    /// In cases where the two affinities conflict, this affinity wins out.
+    pub fn intersect(&mut self, other: &Affinity, reginfo: &RegInfo) {
+        match *self {
+            Affinity::Unassigned => {
+                // Unassigned is the least picky affinity, we can accept anything more precise.
+                *self = other.clone();
+            }
+            Affinity::RegClass(curr_rci) => {
+                // Register class affinities can be narrowed, if a narrower class exists.
+                match other {
+                    Affinity::RegUnit(new_unit) => {
+                        // if the other affinity is for a compatible register, we can use it
+                        if reginfo.rc(curr_rci).contains(*new_unit) {
+                            *self = Affinity::RegUnit(*new_unit);
+                        }
+                    }
+                    Affinity::RegClass(new_rci) => {
+                        // or if the affinity is for a register class more precise than the
+                        // current, we can also use it
+                        if let Some(subclass) =
+                            reginfo.rc(curr_rci).intersect_index(reginfo.rc(*new_rci))
+                        {
+                            *self = Affinity::RegClass(subclass);
+                        }
+                    }
+                    // other cases are either wider or equivalent
+                    _ => {}
+                }
+            }
+            // Either this is already a RegUnit affinity, and either the same or not useful, or
+            // this is a Stack affinity, and the new affinity is conflicting or a no-more-precise
+            // Stack affinity
+            _ => {}
         }
     }
 
@@ -117,9 +183,13 @@ impl<'a> fmt::Display for DisplayAffinity<'a> {
         match self.0 {
             Affinity::Unassigned => write!(f, "unassigned"),
             Affinity::Stack => write!(f, "stack"),
-            Affinity::Reg(rci) => match self.1 {
+            Affinity::RegClass(rci) => match self.1 {
                 Some(regs) => write!(f, "{}", regs.rc(rci)),
                 None => write!(f, "{}", rci),
+            },
+            Affinity::RegUnit(unit) => match self.1 {
+                Some(regs) => write!(f, "{}", regs.display_regunit(unit)),
+                None => write!(f, "{}", unit),
             },
         }
     }

--- a/cranelift-codegen/src/regalloc/liveness.rs
+++ b/cranelift-codegen/src/regalloc/liveness.rs
@@ -232,7 +232,7 @@ fn get_or_create<'a>(
                 } else {
                     // Give normal EBB parameters a register affinity matching their type.
                     let rc = isa.regclass_for_abi_type(func.dfg.value_type(value));
-                    affinity = Affinity::Reg(rc.into());
+                    affinity = Affinity::RegClass(rc.into());
                 }
             }
         };

--- a/cranelift-codegen/src/regalloc/spilling.rs
+++ b/cranelift-codegen/src/regalloc/spilling.rs
@@ -29,6 +29,7 @@ use crate::timing;
 use crate::topo_order::TopoOrder;
 use alloc::vec::Vec;
 use core::fmt;
+use cranelift_entity::EntityRef;
 use log::debug;
 
 /// Persistent data structures for the spilling pass.
@@ -379,9 +380,10 @@ impl<'a> Context<'a> {
             if abi.location.is_reg() {
                 let (rci, spilled) = match self.liveness[arg].affinity {
                     Affinity::RegClass(rci) => (rci, false),
-                    Affinity::RegUnit(_unit) => (
-                        // TODO: Bring up in review
-                        self.cur.isa.regclass_for_abi_type(abi.value_type).into(),
+                    Affinity::RegUnit(unit) => (
+                        RegClassIndex::new(
+                            self.reginfo.toprc_containing_regunit(unit).index as usize,
+                        ),
                         false,
                     ),
                     Affinity::Stack => (

--- a/filetests/regalloc/constraints.clif
+++ b/filetests/regalloc/constraints.clif
@@ -31,12 +31,11 @@ ebb0:
 ; Fixed register constraint.
 function %fixed_op() -> i32 {
 ebb0:
-    ; check: ,%rax]
+    ; The dynamic shift amount must be in %rcx
+    ; check: ,%rcx]
     ; sameln: v0 = iconst.i32 12
     v0 = iconst.i32 12
     v1 = iconst.i32 13
-    ; The dynamic shift amount must be in %rcx
-    ; check: regmove v0, %rax -> %rcx
     v2 = ishl v1, v0
     return v2
 }
@@ -44,12 +43,11 @@ ebb0:
 ; Fixed register constraint twice.
 function %fixed_op_twice() -> i32 {
 ebb0:
-    ; check: ,%rax]
+    ; The dynamic shift amount must be in %rcx
+    ; check: ,%rcx]
     ; sameln: v0 = iconst.i32 12
     v0 = iconst.i32 12
     v1 = iconst.i32 13
-    ; The dynamic shift amount must be in %rcx
-    ; check: regmove v0, %rax -> %rcx
     v2 = ishl v1, v0
     ; check: regmove v0, %rcx -> $REG
     ; check: regmove v2, $REG -> %rcx
@@ -60,13 +58,13 @@ ebb0:
 
 ; Tied use of a diverted register.
 function %fixed_op_twice() -> i32 {
+  fn1 = %f() -> i32
 ebb0:
     ; check: ,%rax]
-    ; sameln: v0 = iconst.i32 12
-    v0 = iconst.i32 12
+    ; sameln: v0 = call fn1()
+    v0 = call fn1()
     v1 = iconst.i32 13
     ; The dynamic shift amount must be in %rcx
-    ; check: regmove v0, %rax -> %rcx
     ; check: v2 = ishl v1, v0
     v2 = ishl v1, v0
 

--- a/filetests/regalloc/register-constraints.clif
+++ b/filetests/regalloc/register-constraints.clif
@@ -1,0 +1,69 @@
+test regalloc
+target x86_64
+
+; test against a regression where using eight general-purpose registers over the
+; end of a basic block could ignore a diversion and result in a miscompile.
+function u0:11(i64 vmctx) -> i32 system_v {
+    gv0 = vmctx
+    gv1 = load.i64 notrap aligned gv0-8
+    heap0 = static gv0, min 0x0002_0000, bound 0x0040_0000, offset_guard 0x0040_0000, index_type i32
+    sig0 = (i64 vmctx, i32) system_v
+    fn0 = colocated u0:10 sig0
+
+    ebb0(v0: i64):
+        v6 = iconst.i32 0
+        v10 = iadd v6, v6
+        v11 = iconst.i32 0
+        v12 = iconst.i32 0
+        v15 = iconst.i32 0
+        v18 = iconst.i32 0
+        v19 = heap_addr.i64 heap0, v6, 1
+        istore8 v18, v6+31
+        v23 = iconst.i64 0
+        store v15, v23
+        store v12, v23
+        store v11, v23
+        call fn0(v0, v10)
+        return v6
+}
+
+; test against an error where variable arguments were checked for constraints incorrectly
+; resulting in a regalloc panic.
+function u0:0(i64, i64, i64) -> i64 system_v {
+    sig0 = (i64) system_v
+    sig1 = () system_v
+    fn0 = u0:28 sig0
+
+     ebb0(v0: i64, v1: i64, v2: i64):
+         v27 = iconst.i32 0
+         brz v27, ebb5
+         jump ebb1
+
+     ebb1:
+         trap user0
+
+     ebb5:
+         v49 = iconst.i32 0
+         brz v49, ebb8
+         jump ebb6
+
+     ebb6:
+         trap user0
+
+     ebb8:
+         v65 = iconst.i32 0
+         brz v65, ebb10
+         jump ebb9
+
+     ebb9:
+         trap user0
+
+     ebb10:
+         v69 = iconst.i64 0
+         call fn0(v69)
+         call_indirect.i64 sig1, v0()
+              jump ebb11
+
+     ebb11:
+         trap user0
+}

--- a/filetests/safepoint/call.clif
+++ b/filetests/safepoint/call.clif
@@ -45,7 +45,6 @@ ebb2:
 ; nextln: 
 ; nextln: ebb1:
 ; nextln:   v11 = fill.r64 v1
-; nextln:   regmove v11, %r15 -> %rax
 ; nextln:   return v11
 ; nextln: 
 ; nextln: ebb2:
@@ -53,6 +52,5 @@ ebb2:
 ; nextln:   safepoint v3
 ; nextln:   v4 = call_indirect sig1, v8()
 ; nextln:   v12 = fill.r64 v3
-; nextln:   regmove v12, %r15 -> %rax
 ; nextln:   return v12
 ; nextln: }

--- a/filetests/wasm/multi-val-b1.clif
+++ b/filetests/wasm/multi-val-b1.clif
@@ -26,14 +26,14 @@ ebb0(v0: b1, v1: b1, v2: b1, v3: b1):
 }
 
 function %call_4_b1s() {
-; check: function %call_4_b1s(i64 fp [%rbp], i64 csr [%rbx]) -> i64 fp [%rbp], i64 csr [%rbx] fast {
-; nextln:    ss0 = sret_slot 4, offset -28
+; check: function %call_4_b1s(i64 fp [%rbp]) -> i64 fp [%rbp] fast {
+; nextln:    ss0 = sret_slot 4, offset -20
 
     fn0 = colocated %return_4_b1s(b1, b1, b1, b1) -> b1, b1, b1, b1
     ; check: sig0 = (b1 [%rsi], b1 [%rdx], b1 [%rcx], b1 [%r8], i64 sret [%rdi]) -> i64 sret [%rax] fast
 
 ebb0:
-; check: ebb0(v26: i64 [%rbp], v27: i64 [%rbx]):
+; check: ebb0(v26: i64 [%rbp]):
 
     v0 = bconst.b1 true
     v1 = bconst.b1 false


### PR DESCRIPTION
The motivation for this change is to avoid the unnecessary `mov`s in code generated for preparing call arguments - what was producing
```
mov rax, qword [rsp]
mov eax, dword [rax + rdx]
mov rdx, qword [rsp]
mov rdi, rdx
mov esi, ecx
mov edx, eax
call <fn>
```

produces, after these changes,
```
mov rax, qword [rsp]
mov edx, dword [rax + rdx]
mov rdi, qword [rsp]
call <fn>
```
yay! :sparkles: 

I'm putting up a PR at this point because while I think these changes are still very messy, I'm at a point where the logical changes seem sound and I'd like to get eyes on that. And if someone has specific style thoughts, I'm more than happy to hear them!

Fundamentally the interesting changes are adding `Affinity::RegUnit`, switching `Affinity::abi` to use that, instead of `Affinity::Reg`, and adjusting coloring to take `Affinity::RegUnit` as a hint on how to color values. Then, when building live ranges, constrain affinity to the ABI-appropriate register. Additionally, because function arguments in my test case were the result of a spill/load, I adjusted `ReloadCandidate` to optionally hint at a specific register to reload into.

Most of the rest of the changes fell out of chasing what used `Affinity::Reg` and needed to learn about `Affinity::RegUnit`, though there's a few cases that don't make a ton of sense to me but seem to result in correct codegen. Comments on those inline.

~~A lot of the messiness here is from adjusting `if let Affinity::Reg(rci) = ... { A }` to `if let Affinity::Reg(rci) = ... { A } else if let Affinity::RegUnit(unit) { B; A }` throughout regalloc. I didn't want to get too tied up in cleaning that up until being sure these changes are the right way to go, but I'm still not sure quite what a nice way to write them would be.~~ (ended up cleaning up most of that here)