### PR TITLE
Skip non-branching instructions when using basic blocks.

### DIFF
--- a/cranelift-codegen/src/cfg_printer.rs
+++ b/cranelift-codegen/src/cfg_printer.rs
@@ -42,7 +42,7 @@ impl<'a> CFGPrinter<'a> {
         for ebb in &self.func.layout {
             write!(w, "    {} [shape=record, label=\"{{{}", ebb, ebb)?;
             // Add all outgoing branch instructions to the label.
-            for inst in self.func.layout.ebb_insts(ebb) {
+            for inst in self.func.layout.ebb_likely_branches(ebb) {
                 let idata = &self.func.dfg[inst];
                 match idata.analyze_branch(&self.func.dfg.value_lists) {
                     BranchInfo::SingleDest(dest, _) => {

--- a/cranelift-codegen/src/dominator_tree.rs
+++ b/cranelift-codegen/src/dominator_tree.rs
@@ -343,7 +343,7 @@ impl DominatorTree {
     /// post-order. Split-invariant means that if an EBB is split in two, we get the same
     /// post-order except for the insertion of the new EBB header at the split point.
     fn push_successors(&mut self, func: &Function, ebb: Ebb) {
-        for inst in func.layout.ebb_insts(ebb) {
+        for inst in func.layout.ebb_likely_branches(ebb) {
             match func.dfg.analyze_branch(inst) {
                 BranchInfo::SingleDest(succ, _) => self.push_if_unseen(succ),
                 BranchInfo::Table(jt, dest) => {

--- a/cranelift-codegen/src/flowgraph.rs
+++ b/cranelift-codegen/src/flowgraph.rs
@@ -120,7 +120,7 @@ impl ControlFlowGraph {
     }
 
     fn compute_ebb(&mut self, func: &Function, ebb: Ebb) {
-        for inst in func.layout.ebb_insts(ebb) {
+        for inst in func.layout.ebb_likely_branches(ebb) {
             match func.dfg.analyze_branch(inst) {
                 BranchInfo::SingleDest(dest, _) => {
                     self.add_edge(ebb, inst, dest);


### PR DESCRIPTION
This changes are replacing the iteration over all instructions by an iteration over the last 2 instructions of basic blocks, when `basic-blocks` feature is enabled.

I am confident this change is likely improving performances. However, until the front-end is completely fixed to generate valid basic blocks, we have no way to check the performances of this code on benchmarks.

I tried running the test suite, but it takes less than a second, which does not give me much confidence.
