### PR TITLE
Add wasm reference/pointers translation.

### DIFF
--- a/cranelift-wasm/src/environ/dummy.rs
+++ b/cranelift-wasm/src/environ/dummy.rs
@@ -5,7 +5,9 @@
 //! [wasmtime-environ]: https://crates.io/crates/wasmtime-environ
 //! [Wasmtime]: https://github.com/bytecodealliance/wasmtime
 
-use crate::environ::{FuncEnvironment, GlobalVariable, ModuleEnvironment, ReturnMode, WasmResult};
+use crate::environ::{
+    FuncEnvironment, GlobalVariable, ModuleEnvironment, ReturnMode, TargetEnvironment, WasmResult,
+};
 use crate::func_translator::FuncTranslator;
 use crate::state::ModuleTranslationState;
 use crate::translation_utils::{
@@ -192,11 +194,13 @@ impl<'dummy_environment> DummyFuncEnvironment<'dummy_environment> {
     }
 }
 
-impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environment> {
+impl<'dummy_environment> TargetEnvironment for DummyFuncEnvironment<'dummy_environment> {
     fn target_config(&self) -> TargetFrontendConfig {
         self.mod_info.config
     }
+}
 
+impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environment> {
     fn return_mode(&self) -> ReturnMode {
         self.return_mode
     }
@@ -454,11 +458,13 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
     }
 }
 
-impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
+impl TargetEnvironment for DummyEnvironment {
     fn target_config(&self) -> TargetFrontendConfig {
         self.info.config
     }
+}
 
+impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
     fn declare_signature(&mut self, sig: ir::Signature) -> WasmResult<()> {
         self.info.signatures.push(sig);
         Ok(())

--- a/cranelift-wasm/src/environ/mod.rs
+++ b/cranelift-wasm/src/environ/mod.rs
@@ -6,5 +6,6 @@ mod spec;
 
 pub use crate::environ::dummy::DummyEnvironment;
 pub use crate::environ::spec::{
-    FuncEnvironment, GlobalVariable, ModuleEnvironment, ReturnMode, WasmError, WasmResult,
+    FuncEnvironment, GlobalVariable, ModuleEnvironment, ReturnMode, TargetEnvironment, WasmError,
+    WasmResult,
 };

--- a/cranelift-wasm/src/func_translator.rs
+++ b/cranelift-wasm/src/func_translator.rs
@@ -193,6 +193,7 @@ fn declare_locals<FE: FuncEnvironment + ?Sized>(
             builder.ins().vconst(ir::types::I8X16, constant_handle)
         }
         AnyRef => builder.ins().null(environ.reference_type()),
+        AnyFunc => builder.ins().null(environ.reference_type()),
         ty => return Err(wasm_unsupported!("unsupported local type {:?}", ty)),
     };
 

--- a/cranelift-wasm/src/lib.rs
+++ b/cranelift-wasm/src/lib.rs
@@ -58,8 +58,8 @@ mod state;
 mod translation_utils;
 
 pub use crate::environ::{
-    DummyEnvironment, FuncEnvironment, GlobalVariable, ModuleEnvironment, ReturnMode, WasmError,
-    WasmResult,
+    DummyEnvironment, FuncEnvironment, GlobalVariable, ModuleEnvironment, ReturnMode,
+    TargetEnvironment, WasmError, WasmResult,
 };
 pub use crate::func_translator::FuncTranslator;
 pub use crate::module_translator::translate_module;

--- a/src/clif-util.rs
+++ b/src/clif-util.rs
@@ -119,6 +119,12 @@ fn add_enable_multi_value<'a>() -> clap::Arg<'a, 'a> {
         .help("Enable WASM's multi-value support")
 }
 
+fn add_enable_reference_types_flag<'a>() -> clap::Arg<'a, 'a> {
+    Arg::with_name("enable-reference-types")
+        .long("enable-reference-types")
+        .help("Enable WASM's reference types operations")
+}
+
 fn add_just_decode_flag<'a>() -> clap::Arg<'a, 'a> {
     Arg::with_name("just-decode")
         .short("t")
@@ -163,6 +169,7 @@ fn add_wasm_or_compile<'a>(cmd: &str) -> clap::App<'a, 'a> {
         .arg(add_debug_flag())
         .arg(add_enable_simd_flag())
         .arg(add_enable_multi_value())
+        .arg(add_enable_reference_types_flag())
         .arg(add_just_decode_flag())
         .arg(add_check_translation_flag())
 }
@@ -316,6 +323,7 @@ fn main() {
                     rest_cmd.is_present("value-ranges"),
                     rest_cmd.is_present("enable-simd"),
                     rest_cmd.is_present("enable-multi-value"),
+                    rest_cmd.is_present("enable-reference-types"),
                 )
             };
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -51,6 +51,7 @@ pub fn run(
     flag_calc_value_ranges: bool,
     flag_enable_simd: bool,
     flag_enable_multi_value: bool,
+    flag_enable_reference_types: bool,
 ) -> Result<(), String> {
     let parsed = parse_sets_and_triple(flag_set, flag_triple)?;
 
@@ -68,6 +69,7 @@ pub fn run(
             flag_calc_value_ranges,
             flag_enable_simd,
             flag_enable_multi_value,
+            flag_enable_reference_types,
             &path.to_path_buf(),
             &name,
             parsed.as_fisa(),
@@ -87,6 +89,7 @@ fn handle_module(
     flag_calc_value_ranges: bool,
     flag_enable_simd: bool,
     flag_enable_multi_value: bool,
+    flag_enable_reference_types: bool,
     path: &PathBuf,
     name: &str,
     fisa: FlagsOrIsa,
@@ -109,6 +112,9 @@ fn handle_module(
         }
         if flag_enable_multi_value {
             features.enable_multi_value();
+        }
+        if flag_enable_reference_types {
+            features.enable_reference_types();
         }
 
         module_binary = match wat2wasm_with_features(&module_binary, features) {


### PR DESCRIPTION
cranelift-wasm is missing conversion of wasm reftypes to cranelift IR. The PR adds capability to translate ref params and locals to IR.

Example: https://gist.github.com/yurydelendik/47b51002f998bccbcad86ace5b62d3d4

/cc @fitzgen 