### PR TITLE
Add a "hidden" argument purpose.

### DIFF
--- a/cranelift-codegen/src/ir/extfunc.rs
+++ b/cranelift-codegen/src/ir/extfunc.rs
@@ -279,13 +279,14 @@ pub enum ArgumentPurpose {
 }
 
 /// Text format names of the `ArgumentPurpose` variants.
-static PURPOSE_NAMES: [&str; 8] = [
+static PURPOSE_NAMES: [&str; 9] = [
     "normal",
     "sret",
     "link",
     "fp",
     "csr",
     "vmctx",
+    "hidden",
     "sigid",
     "stack_limit",
 ];

--- a/cranelift-codegen/src/ir/extfunc.rs
+++ b/cranelift-codegen/src/ir/extfunc.rs
@@ -259,6 +259,12 @@ pub enum ArgumentPurpose {
     /// used as a base pointer for `vmctx` global values.
     VMContext,
 
+    /// A hidden parameter.
+    ///
+    /// This is used for other hidden parameters used in VMs which do not correspond to user
+    /// variables.
+    Hidden,
+
     /// A signature identifier.
     ///
     /// This is a special-purpose argument used to identify the calling convention expected by the
@@ -300,6 +306,7 @@ impl FromStr for ArgumentPurpose {
             "fp" => Ok(ArgumentPurpose::FramePointer),
             "csr" => Ok(ArgumentPurpose::CalleeSaved),
             "vmctx" => Ok(ArgumentPurpose::VMContext),
+            "hidden" => Ok(ArgumentPurpose::Hidden),
             "sigid" => Ok(ArgumentPurpose::SignatureId),
             "stack_limit" => Ok(ArgumentPurpose::StackLimit),
             _ => Err(()),
@@ -357,6 +364,7 @@ mod tests {
             ArgumentPurpose::FramePointer,
             ArgumentPurpose::CalleeSaved,
             ArgumentPurpose::VMContext,
+            ArgumentPurpose::Hidden,
             ArgumentPurpose::SignatureId,
             ArgumentPurpose::StackLimit,
         ];

--- a/cranelift-codegen/src/legalizer/boundary.rs
+++ b/cranelift-codegen/src/legalizer/boundary.rs
@@ -100,6 +100,7 @@ fn legalize_entry_params(func: &mut Function, entry: Ebb) {
                 ArgumentPurpose::Normal => {}
                 ArgumentPurpose::FramePointer => {}
                 ArgumentPurpose::CalleeSaved => {}
+                ArgumentPurpose::Hidden => {}
                 ArgumentPurpose::StructReturn => {
                     debug_assert!(!has_sret, "Multiple sret arguments found");
                     has_sret = true;
@@ -147,7 +148,7 @@ fn legalize_entry_params(func: &mut Function, entry: Ebb) {
     for &arg in &pos.func.signature.params[abi_arg..] {
         match arg.purpose {
             // Any normal parameters should have been processed above.
-            ArgumentPurpose::Normal => {
+            ArgumentPurpose::Normal | ArgumentPurpose::Hidden => {
                 panic!("Leftover arg: {}", arg);
             }
             // The callee-save parameters should not appear until after register allocation is
@@ -602,6 +603,7 @@ pub fn handle_return_abi(inst: Inst, func: &mut Function, cfg: &ControlFlowGraph
             match arg.purpose {
                 ArgumentPurpose::Link
                 | ArgumentPurpose::StructReturn
+                | ArgumentPurpose::Hidden
                 | ArgumentPurpose::VMContext => {}
                 ArgumentPurpose::Normal => panic!("unexpected return value {}", arg),
                 _ => panic!("Unsupported special purpose return value {}", arg),


### PR DESCRIPTION
Add `ArgumentPurpose::Hidden` to allow wasm VMs to pass additional
hidden arguments that don't correspond to wasm arguments.