### PR TITLE
Encode x86 SIMD instructions with REX prefix; fixes #1090

### DIFF
--- a/cranelift-codegen/meta/src/isa/riscv/mod.rs
+++ b/cranelift-codegen/meta/src/isa/riscv/mod.rs
@@ -124,7 +124,7 @@ pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     rv_64.set_encodings(encodings.enc64);
     let encodings_predicates = encodings.inst_pred_reg.extract();
 
-    let recipes = recipes.collect();
+    let recipes = encodings.recipes;
 
     let cpu_modes = vec![rv_32, rv_64];
 


### PR DESCRIPTION
As a preliminary step to this, I re-factored `PerCpuModeEncodings` to reduce some of the issues observed in #955. Although this was not strictly necessary, I felt that changing many of the SIMD encodings was a good time to take a look at `PerCpuModeEncodings`. Stepping through the commits one-by-one should show the re-factoring progression. The final step, adding the REX prefix, should be more clear in the code after the re-factoring.