### PR TITLE
Runtime REX.RB prefix emission for iadd. #1101

### DIFF
--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -452,7 +452,7 @@ pub(crate) fn define<'shared>(
 
     // XX /r with runtime REX emission based on REX.WRB inference.
     recipes.add_recipe(
-        EncodingRecipeBuilder::new("DynRexOp1rr", &formats.binary, 1)
+        EncodingRecipeBuilder::new("DynRexOp1rr", &formats.binary, 2)
             .operands_in(vec![gpr, gpr])
             .operands_out(vec![0])
             .compute_size("size_with_rex_inference_for_two_in_regs")
@@ -546,7 +546,7 @@ pub(crate) fn define<'shared>(
 
     // XX /r with runtime REX emission based on REX.WRB inference.
     recipes.add_recipe(
-        EncodingRecipeBuilder::new("DynRexOp1ur", &formats.unary, 1)
+        EncodingRecipeBuilder::new("DynRexOp1ur", &formats.unary, 2)
             .operands_in(vec![gpr])
             .operands_out(vec![0])
             .compute_size("size_with_rex_inference_for_one_in_reg")


### PR DESCRIPTION
This is a WIP patch for #1101, runtime REX prefix emission. Seeking comment from @bnjbvr as to whether this was what he had in mind before I go and convert other instructions to a similar format.

This patch generates the REX prefix for x86_64 32-bit instructions at runtime based on the register selection.

The recipe is generated as:

```rust
        // Recipe Op1rr_runtime_rex_rb
        3 => {
            if let InstructionData::Binary {
                opcode,
                ref args,
                ..
            } = *inst_data {
                let in_reg0 = divert.reg(args[0], &func.locations);
                let in_reg1 = divert.reg(args[1], &func.locations);
                let rex_byte = rex2(in_reg0, in_reg1);
                // The "put" functions assert whether the REX prefix is needed.
                if rex_byte == BASE_REX {
                    put_op1(bits, rex_byte, sink);
                } else {
                    put_rexop1(bits, rex_byte, sink);
                }
                modrm_rr(in_reg0, in_reg1, sink);
                return;
            }
        }
```

There is some code (that I don't understand yet) that seems to allow `Encoding`s to be polymorphic for a limited number of cases. That might also allow merging the x86_64 I32 and I64 cases by emission-time hashtable lookup on the inst Type in the DFG cond_typevar array.

I tried to do that first but got a bit lost, because the syntax `.bind().bind()` seems to be binding input register types. I don't know if a mechanism for multi-type encodings exists yet. Commentary on that would be appreciated!