### PR TITLE
Tls support for ELF and MachO

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -340,7 +340,7 @@ impl InstructionBuilder {
         let polymorphic_info =
             verify_polymorphic(&operands_in, &operands_out, &self.format, &value_opnums);
 
-        // Infer from output operands whether an instruciton clobbers CPU flags or not.
+        // Infer from output operands whether an instruction clobbers CPU flags or not.
         let writes_cpu_flags = operands_out.iter().any(|op| op.is_cpu_flags());
 
         let camel_name = camel_case(&self.name);

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -2407,5 +2407,14 @@ pub(crate) fn define(
     define_control_flow(&mut e, shared_defs, settings, r);
     define_reftypes(&mut e, shared_defs, r);
 
+    let x86_elf_tls_get_addr = x86.by_name("x86_elf_tls_get_addr");
+    let x86_macho_tls_get_addr = x86.by_name("x86_macho_tls_get_addr");
+
+    let rec_elf_tls_get_addr = r.recipe("elf_tls_get_addr");
+    let rec_macho_tls_get_addr = r.recipe("macho_tls_get_addr");
+
+    e.enc64_rec(x86_elf_tls_get_addr, rec_elf_tls_get_addr, 0);
+    e.enc64_rec(x86_macho_tls_get_addr, rec_macho_tls_get_addr, 0);
+
     e
 }

--- a/cranelift-codegen/meta/src/isa/x86/instructions.rs
+++ b/cranelift-codegen/meta/src/isa/x86/instructions.rs
@@ -552,7 +552,6 @@ pub(crate) fn define(
 
     let GV = &Operand::new("GV", &entities.global_value);
     let addr = &Operand::new("addr", i64_t);
-    let clobber = &Operand::new("clobber", i64_t); // FIXME remove need for this
 
     ig.push(
         Inst::new(
@@ -564,7 +563,7 @@ pub(crate) fn define(
             &formats.unary_global_value,
         )
         .operands_in(vec![GV])
-        .operands_out(vec![addr, clobber]),
+        .operands_out(vec![addr]),
     );
     ig.push(
         Inst::new(
@@ -576,7 +575,7 @@ pub(crate) fn define(
             &formats.unary_global_value,
         )
         .operands_in(vec![GV])
-        .operands_out(vec![addr, clobber]),
+        .operands_out(vec![addr]),
     );
 
     ig.build()

--- a/cranelift-codegen/meta/src/isa/x86/instructions.rs
+++ b/cranelift-codegen/meta/src/isa/x86/instructions.rs
@@ -7,6 +7,7 @@ use crate::cdsl::operands::Operand;
 use crate::cdsl::types::ValueType;
 use crate::cdsl::typevar::{Interval, TypeSetBuilder, TypeVar};
 
+use crate::shared::entities::EntityRefs;
 use crate::shared::formats::Formats;
 use crate::shared::immediates::Immediates;
 use crate::shared::types;
@@ -16,6 +17,7 @@ pub(crate) fn define(
     mut all_instructions: &mut AllInstructions,
     formats: &Formats,
     immediates: &Immediates,
+    entities: &EntityRefs,
 ) -> InstructionGroup {
     let mut ig = InstructionGroupBuilder::new(&mut all_instructions);
 
@@ -540,6 +542,41 @@ pub(crate) fn define(
         )
         .operands_in(vec![x, y])
         .operands_out(vec![a]),
+    );
+
+    let i64_t = &TypeVar::new(
+        "i64_t",
+        "A scalar 64bit integer",
+        TypeSetBuilder::new().ints(64..64).build(),
+    );
+
+    let GV = &Operand::new("GV", &entities.global_value);
+    let addr = &Operand::new("addr", i64_t);
+    let clobber = &Operand::new("clobber", i64_t); // FIXME remove need for this
+
+    ig.push(
+        Inst::new(
+            "x86_elf_tls_get_addr",
+            r#"
+        Elf tls get addr -- This implements the GD TLS model for ELF. The clobber output should
+        not be used.
+            "#,
+            &formats.unary_global_value,
+        )
+        .operands_in(vec![GV])
+        .operands_out(vec![addr, clobber]),
+    );
+    ig.push(
+        Inst::new(
+            "x86_macho_tls_get_addr",
+            r#"
+        Mach-O tls get addr -- This implements TLS access for Mach-O. The clobber output should
+        not be used.
+            "#,
+            &formats.unary_global_value,
+        )
+        .operands_in(vec![GV])
+        .operands_out(vec![addr, clobber]),
     );
 
     ig.build()

--- a/cranelift-codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift-codegen/meta/src/isa/x86/legalize.rs
@@ -61,6 +61,7 @@ pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &Instruct
     let shuffle = insts.by_name("shuffle");
     let srem = insts.by_name("srem");
     let sshr = insts.by_name("sshr");
+    let tls_value = insts.by_name("tls_value");
     let trueif = insts.by_name("trueif");
     let udiv = insts.by_name("udiv");
     let umax = insts.by_name("umax");
@@ -325,6 +326,8 @@ pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &Instruct
     );
 
     group.custom_legalize(ineg, "convert_ineg");
+
+    group.custom_legalize(tls_value, "expand_tls_value");
 
     group.build_and_add_to(&mut shared.transform_groups);
 

--- a/cranelift-codegen/meta/src/isa/x86/mod.rs
+++ b/cranelift-codegen/meta/src/isa/x86/mod.rs
@@ -24,6 +24,7 @@ pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
         &mut shared_defs.all_instructions,
         &shared_defs.formats,
         &shared_defs.imm,
+        &shared_defs.entities,
     );
     legalize::define(shared_defs, &inst_group);
 

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -393,7 +393,6 @@ pub(crate) fn define<'shared>(
     let reg_rax = Register::new(gpr, regs.regunit_by_name(gpr, "rax"));
     let reg_rcx = Register::new(gpr, regs.regunit_by_name(gpr, "rcx"));
     let reg_rdx = Register::new(gpr, regs.regunit_by_name(gpr, "rdx"));
-    let reg_rdi = Register::new(gpr, regs.regunit_by_name(gpr, "rdi"));
     let reg_r15 = Register::new(gpr, regs.regunit_by_name(gpr, "r15"));
 
     // Stack operand with a 32-bit signed displacement from either RBP or RSP.
@@ -3265,10 +3264,13 @@ pub(crate) fn define<'shared>(
         ),
     );
 
+    // Both `elf_tls_get_addr` and `macho_tls_get_addr` require all caller-saved registers to be spilled.
+    // This is currently special cased in `regalloc/spilling.rs` in the `visit_inst` function.
+
     recipes.add_recipe(
         EncodingRecipeBuilder::new("elf_tls_get_addr", &formats.unary_global_value, 16)
             // FIXME Correct encoding for non rax registers
-            .operands_out(vec![reg_rax, reg_rdi])
+            .operands_out(vec![reg_rax])
             .emit(
                 r#"
                     // output %rax
@@ -3303,7 +3305,7 @@ pub(crate) fn define<'shared>(
     recipes.add_recipe(
         EncodingRecipeBuilder::new("macho_tls_get_addr", &formats.unary_global_value, 9)
             // FIXME Correct encoding for non rax registers
-            .operands_out(vec![reg_rax, reg_rdi])
+            .operands_out(vec![reg_rax])
             .emit(
                 r#"
                     // output %rax

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -1127,6 +1127,18 @@ pub(crate) fn define(
         .operands_out(vec![a]),
     );
 
+    ig.push(
+        Inst::new(
+            "tls_value",
+            r#"
+        Compute the value of global GV, which is a TLS (thread local storage) value.
+        "#,
+            &formats.unary_global_value,
+        )
+        .operands_in(vec![GV])
+        .operands_out(vec![a]),
+    );
+
     let HeapOffset = &TypeVar::new(
         "HeapOffset",
         "An unsigned heap offset",

--- a/cranelift-codegen/meta/src/shared/mod.rs
+++ b/cranelift-codegen/meta/src/shared/mod.rs
@@ -1,6 +1,6 @@
 //! Shared definitions for the Cranelift intermediate language.
 
-mod entities;
+pub mod entities;
 pub mod formats;
 pub mod immediates;
 pub mod instructions;
@@ -28,6 +28,7 @@ pub(crate) struct Definitions {
     pub imm: Immediates,
     pub formats: Formats,
     pub transform_groups: TransformGroups,
+    pub entities: EntityRefs,
 }
 
 pub(crate) fn define() -> Definitions {
@@ -47,6 +48,7 @@ pub(crate) fn define() -> Definitions {
         imm: immediates,
         formats,
         transform_groups,
+        entities,
     }
 }
 

--- a/cranelift-codegen/meta/src/shared/settings.rs
+++ b/cranelift-codegen/meta/src/shared/settings.rs
@@ -131,6 +131,14 @@ pub(crate) fn define() -> SettingGroup {
         false,
     );
 
+    settings.add_enum(
+        "tls_model",
+        r#"
+            Defines the model used to perform TLS accesses.
+        "#,
+        vec!["none", "elf_gd", "macho", "coff"],
+    );
+
     // Settings specific to the `baldrdash` calling convention.
 
     settings.add_enum(

--- a/cranelift-codegen/src/binemit/mod.rs
+++ b/cranelift-codegen/src/binemit/mod.rs
@@ -56,6 +56,12 @@ pub enum Reloc {
     Arm64Call,
     /// RISC-V call target
     RiscvCall,
+
+    /// Elf x86_64 32 bit signed PC relative offset to two GOT entries for GD symbol.
+    ElfX86_64TlsGd,
+
+    /// Mach-O x86_64 32 bit signed PC relative offset to a `__thread_vars` entry.
+    MachOX86_64Tlv,
 }
 
 impl fmt::Display for Reloc {
@@ -71,6 +77,9 @@ impl fmt::Display for Reloc {
             Self::X86CallPLTRel4 => write!(f, "CallPLTRel4"),
             Self::X86GOTPCRel4 => write!(f, "GOTPCRel4"),
             Self::Arm32Call | Self::Arm64Call | Self::RiscvCall => write!(f, "Call"),
+
+            Self::ElfX86_64TlsGd => write!(f, "ElfX86_64TlsGd"),
+            Self::MachOX86_64Tlv => write!(f, "MachOX86_64Tlv"),
         }
     }
 }

--- a/cranelift-codegen/src/ir/globalvalue.rs
+++ b/cranelift-codegen/src/ir/globalvalue.rs
@@ -63,6 +63,9 @@ pub enum GlobalValueData {
         /// away, after linking? If so, references to it can avoid going through a GOT. Note that
         /// symbols meant to be preemptible cannot be colocated.
         colocated: bool,
+
+        /// Does this symbol refer to a thread local storage value?
+        tls: bool,
     },
 }
 
@@ -110,11 +113,13 @@ impl fmt::Display for GlobalValueData {
                 ref name,
                 offset,
                 colocated,
+                tls,
             } => {
                 write!(
                     f,
-                    "symbol {}{}",
+                    "symbol {}{}{}",
                     if colocated { "colocated " } else { "" },
+                    if tls { "tls " } else { "" },
                     name
                 )?;
                 let offset_val: i64 = offset.into();

--- a/cranelift-codegen/src/ir/libcall.rs
+++ b/cranelift-codegen/src/ir/libcall.rs
@@ -46,6 +46,9 @@ pub enum LibCall {
     Memset,
     /// libc.memmove
     Memmove,
+
+    /// Elf __tls_get_addr
+    ElfTlsGetAddr,
 }
 
 impl fmt::Display for LibCall {
@@ -71,6 +74,8 @@ impl FromStr for LibCall {
             "Memcpy" => Ok(Self::Memcpy),
             "Memset" => Ok(Self::Memset),
             "Memmove" => Ok(Self::Memmove),
+
+            "ElfTlsGetAddr" => Ok(Self::ElfTlsGetAddr),
             _ => Err(()),
         }
     }

--- a/cranelift-codegen/src/isa/x86/binemit.rs
+++ b/cranelift-codegen/src/isa/x86/binemit.rs
@@ -4,7 +4,10 @@ use super::enc_tables::{needs_offset, needs_sib_byte};
 use super::registers::RU;
 use crate::binemit::{bad_encoding, CodeSink, Reloc};
 use crate::ir::condcodes::{CondCode, FloatCC, IntCC};
-use crate::ir::{Block, Constant, Function, Inst, InstructionData, JumpTable, Opcode, TrapCode};
+use crate::ir::{
+    Block, Constant, ExternalName, Function, Inst, InstructionData, JumpTable, LibCall, Opcode,
+    TrapCode,
+};
 use crate::isa::{RegUnit, StackBase, StackBaseMask, StackRef, TargetIsa};
 use crate::regalloc::RegDiversions;
 

--- a/cranelift-codegen/src/isa/x86/enc_tables.rs
+++ b/cranelift-codegen/src/isa/x86/enc_tables.rs
@@ -1288,3 +1288,47 @@ fn convert_ineg(
         unreachable!()
     }
 }
+
+fn expand_tls_value(
+    inst: ir::Inst,
+    func: &mut ir::Function,
+    _cfg: &mut ControlFlowGraph,
+    isa: &dyn TargetIsa,
+) {
+    use crate::settings::TlsModel;
+
+    assert!(
+        isa.triple().architecture == target_lexicon::Architecture::X86_64,
+        "Not yet implemented for {:?}",
+        isa.triple(),
+    );
+
+    if let ir::InstructionData::UnaryGlobalValue {
+        opcode: ir::Opcode::TlsValue,
+        global_value,
+    } = func.dfg[inst]
+    {
+        let ctrl_typevar = func.dfg.ctrl_typevar(inst);
+        assert_eq!(ctrl_typevar, ir::types::I64);
+
+        let return_value = match func
+            .dfg
+            .detach_results(inst)
+            .as_slice(&func.dfg.value_lists)
+        {
+            &[return_value] => return_value,
+            _ => unreachable!(),
+        };
+
+        let (tls_addr, _clobber) = match isa.flags().tls_model() {
+            TlsModel::None => panic!("tls_model flag is not set."),
+            TlsModel::ElfGd => func.dfg.replace(inst).x86_elf_tls_get_addr(global_value),
+            TlsModel::Macho => func.dfg.replace(inst).x86_macho_tls_get_addr(global_value),
+            model => unimplemented!("tls_value for tls model {:?}", model),
+        };
+
+        func.dfg.change_to_alias(return_value, tls_addr);
+    } else {
+        unreachable!();
+    }
+}

--- a/cranelift-codegen/src/isa/x86/enc_tables.rs
+++ b/cranelift-codegen/src/isa/x86/enc_tables.rs
@@ -1311,23 +1311,16 @@ fn expand_tls_value(
         let ctrl_typevar = func.dfg.ctrl_typevar(inst);
         assert_eq!(ctrl_typevar, ir::types::I64);
 
-        let return_value = match func
-            .dfg
-            .detach_results(inst)
-            .as_slice(&func.dfg.value_lists)
-        {
-            &[return_value] => return_value,
-            _ => unreachable!(),
-        };
-
-        let (tls_addr, _clobber) = match isa.flags().tls_model() {
+        match isa.flags().tls_model() {
             TlsModel::None => panic!("tls_model flag is not set."),
-            TlsModel::ElfGd => func.dfg.replace(inst).x86_elf_tls_get_addr(global_value),
-            TlsModel::Macho => func.dfg.replace(inst).x86_macho_tls_get_addr(global_value),
+            TlsModel::ElfGd => {
+                func.dfg.replace(inst).x86_elf_tls_get_addr(global_value);
+            }
+            TlsModel::Macho => {
+                func.dfg.replace(inst).x86_macho_tls_get_addr(global_value);
+            }
             model => unimplemented!("tls_value for tls model {:?}", model),
-        };
-
-        func.dfg.change_to_alias(return_value, tls_addr);
+        }
     } else {
         unreachable!();
     }

--- a/cranelift-codegen/src/legalizer/globalvalue.rs
+++ b/cranelift-codegen/src/legalizer/globalvalue.rs
@@ -40,7 +40,7 @@ pub fn expand_global_value(
             global_type,
             readonly,
         } => load_addr(inst, func, base, offset, global_type, readonly, isa),
-        ir::GlobalValueData::Symbol { .. } => symbol(inst, func, gv, isa),
+        ir::GlobalValueData::Symbol { tls, .. } => symbol(inst, func, gv, isa, tls),
     }
 }
 
@@ -123,7 +123,18 @@ fn load_addr(
 }
 
 /// Expand a `global_value` instruction for a symbolic name global.
-fn symbol(inst: ir::Inst, func: &mut ir::Function, gv: ir::GlobalValue, isa: &dyn TargetIsa) {
+fn symbol(
+    inst: ir::Inst,
+    func: &mut ir::Function,
+    gv: ir::GlobalValue,
+    isa: &dyn TargetIsa,
+    tls: bool,
+) {
     let ptr_ty = isa.pointer_type();
-    func.dfg.replace(inst).symbol_value(ptr_ty, gv);
+
+    if tls {
+        func.dfg.replace(inst).tls_value(ptr_ty, gv);
+    } else {
+        func.dfg.replace(inst).symbol_value(ptr_ty, gv);
+    }
 }

--- a/cranelift-codegen/src/regalloc/spilling.rs
+++ b/cranelift-codegen/src/regalloc/spilling.rs
@@ -267,7 +267,11 @@ impl<'a> Context<'a> {
         // If inst is a call, spill all register values that are live across the call.
         // This means that we don't currently take advantage of callee-saved registers.
         // TODO: Be more sophisticated.
-        if call_sig.is_some() {
+        let opcode = self.cur.func.dfg[inst].opcode();
+        if call_sig.is_some()
+            || opcode == crate::ir::Opcode::X86ElfTlsGetAddr
+            || opcode == crate::ir::Opcode::X86MachoTlsGetAddr
+        {
             for lv in throughs {
                 if lv.affinity.is_reg() && !self.spills.contains(&lv.value) {
                     self.spill_reg(lv.value);

--- a/cranelift-codegen/src/settings.rs
+++ b/cranelift-codegen/src/settings.rs
@@ -379,6 +379,7 @@ mod tests {
             f.to_string(),
             "[shared]\n\
              opt_level = \"none\"\n\
+             tls_model = \"none\"\n\
              libcall_call_conv = \"isa_default\"\n\
              baldrdash_prologue_words = 0\n\
              probestack_size_log2 = 12\n\

--- a/cranelift-faerie/src/backend.rs
+++ b/cranelift-faerie/src/backend.rs
@@ -136,8 +136,10 @@ impl Backend for FaerieBackend {
         name: &str,
         linkage: Linkage,
         writable: bool,
+        tls: bool,
         align: Option<u8>,
     ) {
+        assert!(!tls, "Faerie doesn't yet support TLS");
         self.artifact
             .declare(name, translate_data_linkage(linkage, writable, align))
             .expect("inconsistent declarations");
@@ -231,10 +233,12 @@ impl Backend for FaerieBackend {
         _id: DataId,
         name: &str,
         _writable: bool,
+        tls: bool,
         _align: Option<u8>,
         data_ctx: &DataContext,
         namespace: &ModuleNamespace<Self>,
     ) -> ModuleResult<FaerieCompiledData> {
+        assert!(!tls, "Faerie doesn't yet support TLS");
         let &DataDescription {
             ref init,
             ref function_decls,

--- a/cranelift-module/src/backend.rs
+++ b/cranelift-module/src/backend.rs
@@ -72,6 +72,7 @@ where
         name: &str,
         linkage: Linkage,
         writable: bool,
+        tls: bool,
         align: Option<u8>,
     );
 
@@ -107,6 +108,7 @@ where
         id: DataId,
         name: &str,
         writable: bool,
+        tls: bool,
         align: Option<u8>,
         data_ctx: &DataContext,
         namespace: &ModuleNamespace<Self>,
@@ -188,5 +190,7 @@ pub fn default_libcall_names() -> Box<dyn Fn(ir::LibCall) -> String> {
         ir::LibCall::Memcpy => "memcpy".to_owned(),
         ir::LibCall::Memset => "memset".to_owned(),
         ir::LibCall::Memmove => "memmove".to_owned(),
+
+        ir::LibCall::ElfTlsGetAddr => "__tls_get_addr".to_owned(),
     })
 }

--- a/cranelift-object/Cargo.toml
+++ b/cranelift-object/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 cranelift-module = { path = "../cranelift-module", version = "0.59.0" }
 object = { version = "0.17", default-features = false, features = ["write"] }
 target-lexicon = "0.10"
+goblin = "0.1.0"
 
 [dependencies.cranelift-codegen]
 path = "../cranelift-codegen"

--- a/cranelift-reader/src/parser.rs
+++ b/cranelift-reader/src/parser.rs
@@ -204,6 +204,7 @@ impl<'a> Context<'a> {
                 name: ExternalName::testcase(""),
                 offset: Imm64::new(0),
                 colocated: false,
+                tls: false,
             });
         }
         self.function.global_values[gv] = data;
@@ -1443,12 +1444,14 @@ impl<'a> Parser<'a> {
             }
             "symbol" => {
                 let colocated = self.optional(Token::Identifier("colocated"));
+                let tls = self.optional(Token::Identifier("tls"));
                 let name = self.parse_external_name()?;
                 let offset = self.optional_offset_imm64()?;
                 GlobalValueData::Symbol {
                     name,
                     offset,
                     colocated,
+                    tls,
                 }
             }
             other => return err!(self.loc, "Unknown global value kind '{}'", other),

--- a/cranelift-simplejit/src/backend.rs
+++ b/cranelift-simplejit/src/backend.rs
@@ -264,8 +264,10 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
         _name: &str,
         _linkage: Linkage,
         _writable: bool,
+        tls: bool,
         _align: Option<u8>,
     ) {
+        assert!(!tls, "SimpleJIT doesn't yet support TLS");
         // Nothing to do.
     }
 
@@ -341,10 +343,13 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
         _id: DataId,
         _name: &str,
         writable: bool,
+        tls: bool,
         align: Option<u8>,
         data: &DataContext,
         _namespace: &ModuleNamespace<Self>,
     ) -> ModuleResult<Self::CompiledData> {
+        assert!(!tls, "SimpleJIT doesn't yet support TLS");
+
         let &DataDescription {
             ref init,
             ref function_decls,

--- a/filetests/isa/x86/tls_elf.clif
+++ b/filetests/isa/x86/tls_elf.clif
@@ -1,0 +1,14 @@
+test legalizer
+set tls_model=elf_gd
+target x86_64
+
+function u0:0() -> i64 {
+gv0 = symbol colocated tls u1:0
+
+block0:
+    v0 = global_value.i64 gv0
+    ; check: v1, v2 = x86_elf_tls_get_addr gv0
+    ; nextln: v0 -> v1
+    return v0
+    ; nextln: return v0
+}

--- a/filetests/isa/x86/tls_elf.clif
+++ b/filetests/isa/x86/tls_elf.clif
@@ -1,14 +1,18 @@
-test legalizer
+test regalloc
 set tls_model=elf_gd
 target x86_64
 
-function u0:0() -> i64 {
+function u0:0(i32) -> i32, i64 {
 gv0 = symbol colocated tls u1:0
 
-block0:
-    v0 = global_value.i64 gv0
-    ; check: v1, v2 = x86_elf_tls_get_addr gv0
-    ; nextln: v0 -> v1
-    return v0
-    ; nextln: return v0
+block0(v0: i32):
+    ; check: block0(v2: i32 [%rdi]):
+    ; nextln: [RexOp1spillSib32#89,ss0]           v0 = spill v2
+    v1 = global_value.i64 gv0
+    ; nextln: [elf_tls_get_addr#00,%rax]          v1 = x86_elf_tls_get_addr gv0
+    ; nextln: [RexOp1fillSib32#8b,%r15]           v3 = fill v0
+    return v0, v1
+    ; nextln: [RexOp1rmov#8089]                   regmove v1, %rax -> %rdx
+    ; nextln: [RexOp1rmov#89]                     regmove v3, %r15 -> %rax
+    ; nextln: [Op1ret#c3]                         return v3, v1
 }

--- a/filetests/isa/x86/tls_enc.clif
+++ b/filetests/isa/x86/tls_enc.clif
@@ -1,0 +1,11 @@
+test binemit
+target x86_64
+
+function u0:0() -> i64, i64 {
+gv0 = symbol colocated tls u1:0
+
+block0:
+    [-, %rax, %rdi] v0, v1 = x86_elf_tls_get_addr gv0 ; bin: 66 48 8d 3d ElfX86_64TlsGd(u1:0-4) 00000000 66 66 48 e8 CallPLTRel4(%ElfTlsGetAddr-4) 00000000
+    [-, %rax, %rdi] v2, v3 = x86_macho_tls_get_addr gv0; bin: 48 8b 3d MachOX86_64Tlv(u1:0-4) 00000000 ff 17
+    return v0, v2
+}

--- a/filetests/isa/x86/tls_enc.clif
+++ b/filetests/isa/x86/tls_enc.clif
@@ -5,7 +5,7 @@ function u0:0() -> i64, i64 {
 gv0 = symbol colocated tls u1:0
 
 block0:
-    [-, %rax, %rdi] v0, v1 = x86_elf_tls_get_addr gv0 ; bin: 66 48 8d 3d ElfX86_64TlsGd(u1:0-4) 00000000 66 66 48 e8 CallPLTRel4(%ElfTlsGetAddr-4) 00000000
-    [-, %rax, %rdi] v2, v3 = x86_macho_tls_get_addr gv0; bin: 48 8b 3d MachOX86_64Tlv(u1:0-4) 00000000 ff 17
-    return v0, v2
+    [-, %rax] v0 = x86_elf_tls_get_addr gv0 ; bin: 66 48 8d 3d ElfX86_64TlsGd(u1:0-4) 00000000 66 66 48 e8 CallPLTRel4(%ElfTlsGetAddr-4) 00000000
+    [-, %rax] v1 = x86_macho_tls_get_addr gv0; bin: 48 8b 3d MachOX86_64Tlv(u1:0-4) 00000000 ff 17
+    return v0, v1
 }

--- a/filetests/isa/x86/tls_macho.clif
+++ b/filetests/isa/x86/tls_macho.clif
@@ -1,14 +1,18 @@
-test legalizer
+test regalloc
 set tls_model=macho
 target x86_64
 
-function u0:0() -> i64 {
+function u0:0(i32) -> i32, i64 {
 gv0 = symbol colocated tls u1:0
 
-block0:
-    v0 = global_value.i64 gv0
-    ; check: v1, v2 = x86_macho_tls_get_addr gv0
-    ; nextln: v0 -> v1
-    return v0
-    ; nextln: return v0
+block0(v0: i32):
+    ; check: block0(v2: i32 [%rdi]):
+    ; nextln: [RexOp1spillSib32#89,ss0]           v0 = spill v2
+    v1 = global_value.i64 gv0
+    ; nextln: [macho_tls_get_addr#00,%rax]        v1 = x86_macho_tls_get_addr gv0
+    ; nextln: [RexOp1fillSib32#8b,%r15]           v3 = fill v0
+    return v0, v1
+    ; nextln: [RexOp1rmov#8089]                   regmove v1, %rax -> %rdx
+    ; nextln: [RexOp1rmov#89]                     regmove v3, %r15 -> %rax
+    ; nextln: [Op1ret#c3]                         return v3, v1
 }

--- a/filetests/isa/x86/tls_macho.clif
+++ b/filetests/isa/x86/tls_macho.clif
@@ -1,0 +1,14 @@
+test legalizer
+set tls_model=macho
+target x86_64
+
+function u0:0() -> i64 {
+gv0 = symbol colocated tls u1:0
+
+block0:
+    v0 = global_value.i64 gv0
+    ; check: v1, v2 = x86_macho_tls_get_addr gv0
+    ; nextln: v0 -> v1
+    return v0
+    ; nextln: return v0
+}


### PR DESCRIPTION
This adds TLS (thread local storage) support for ELF targets to Cranelift

* [x] ASM of the `tls_example.clif` file has been verifier to match the ASM emitted by LLVM at https://github.com/bjorn3/rustc_codegen_cranelift/issues/388#issuecomment-531466812
* [x] Test runtime: object::write doesn't have enough TLS support yet to test execution.
* [x] Verify encodings are correct and idiomatic.
* [x] Rustfmt
* [x] Add flag to switch between TLS styles (ELF, machO) and set it automatically from either codegen or backends.
* [x] Add tests

- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. <strike>The list of suggested reviewers on the right can help you.</strike> No list of suggested reviewers shown on the right side.

Fixes #963

cc @philipc https://github.com/bjorn3/rustc_codegen_cranelift/issues/388#issuecomment-526909856
cc @abrown Because you implemented SIMD support for x86, I think you know enough of x86 encodings to verify that the encodings are correct.