### PR TITLE
Added run tests for i128.icmp

### DIFF
--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -723,6 +723,7 @@ pub(crate) fn define(
     e.enc_both(band.bind(B1), rec_rr.opcodes(&AND));
     e.enc_both(bor.bind(B1), rec_rr.opcodes(&OR));
     e.enc_both(bxor.bind(B1), rec_rr.opcodes(&XOR));
+    e.enc_both(bnot.bind(B1), rec_ur.opcodes(&NOT).rrr(2));
 
     e.enc_i32_i64(imul, rec_rrx.opcodes(&IMUL));
     e.enc_i32_i64(x86_sdivmodx, rec_div.opcodes(&IDIV).rrr(7));

--- a/filetests/isa/x86/icmp-i128.clif
+++ b/filetests/isa/x86/icmp-i128.clif
@@ -50,3 +50,59 @@ ebb0:
 }
 
 ; run
+
+function %test_icmp_nz_eq_i128() -> b1 {
+ebb0:
+    v11 = iconst.i64 0x1
+    v12 = iconst.i64 0x1
+    v1 = iconcat v11, v12
+    v21 = iconst.i64 0x1
+    v22 = iconst.i64 0x1
+    v2 = iconcat v21, v22
+    v10 = icmp.i128 eq v1, v2
+    return v10
+}
+
+; run
+
+function %test_icmp_nz_gt_i128() -> b1 {
+ebb0:
+    v11 = iconst.i64 0x1
+    v12 = iconst.i64 0x1
+    v1 = iconcat v11, v12
+    v21 = iconst.i64 0x2
+    v22 = iconst.i64 0x2
+    v2 = iconcat v21, v22
+    v10 = icmp.i128 ugt v2, v1
+    return v10
+}
+
+; run
+
+function %test_icmp_nz_ge_not_eq_i128() -> b1 {
+ebb0:
+    v11 = iconst.i64 0x1
+    v12 = iconst.i64 0x1
+    v1 = iconcat v11, v12
+    v21 = iconst.i64 0x2
+    v22 = iconst.i64 0x2
+    v2 = iconcat v21, v22
+    v10 = icmp.i128 uge v2, v1
+    return v10
+}
+
+; run
+
+function %test_icmp_nz_ge_eq_i128() -> b1 {
+ebb0:
+    v11 = iconst.i64 0x2
+    v12 = iconst.i64 0x2
+    v1 = iconcat v11, v12
+    v21 = iconst.i64 0x2
+    v22 = iconst.i64 0x2
+    v2 = iconcat v21, v22
+    v10 = icmp.i128 uge v2, v1
+    return v10
+}
+
+; run


### PR DESCRIPTION
### Summary

This PR is for issue #1131. Writing the greater than test case required I write a legalization for `bnot.b1`, so this PR also affects issue #1117.

Added run tests for `i128.icmp` to the file `filetests/isa/x86/icmp-i128.clif`, for condition codes equal, greater than, and greater than or equal¹ using non-zero values.

Legalized `bnot.b1` as it was required for at least the `greater than` `icmp` condition code.

### Notes

I squashed the commits for both the test case additions and the legalization into one commit. Let me know if it would be better to have those as two commits, I can separate those changes again.

I'm not sure if my legalization and/or tests cases are correct. The documentation on `icmp`s condition codes doesn't mention operand order in the comparisons. I also only added test cases for unsigned values, but can easily add test cases for unsigned values.

1: https://docs.rs/cranelift-codegen/0.46.1/cranelift_codegen/ir/trait.InstBuilder.html#method.icmp