### PR TITLE
Use zeroinit API for faerie and object

### DIFF
--- a/cranelift-faerie/src/backend.rs
+++ b/cranelift-faerie/src/backend.rs
@@ -217,20 +217,6 @@ impl Backend for FaerieBackend {
             ref data_relocs,
         } = data_ctx.description();
 
-        let size = init.size();
-        let mut bytes = Vec::with_capacity(size);
-        match *init {
-            Init::Uninitialized => {
-                panic!("data is not initialized yet");
-            }
-            Init::Zeros { .. } => {
-                bytes.resize(size, 0);
-            }
-            Init::Bytes { ref contents } => {
-                bytes.extend_from_slice(contents);
-            }
-        }
-
         for &(offset, id) in function_relocs {
             let to = &namespace.get_function_decl(&function_decls[id]).name;
             self.artifact
@@ -256,9 +242,25 @@ impl Backend for FaerieBackend {
                 .map_err(|e| ModuleError::Backend(e.to_string()))?;
         }
 
-        self.artifact
-            .define(name, bytes)
-            .expect("inconsistent declaration");
+        let size = init.size();
+        let mut bytes = Vec::with_capacity(size);
+        match *init {
+            Init::Uninitialized => {
+                panic!("data is not initialized yet");
+            }
+            Init::Zeros { .. } => {
+                self.artifact
+                    .define_zero_init(name, size)
+                    .expect("inconsistent declaration");
+            }
+            Init::Bytes { ref contents } => {
+                bytes.extend_from_slice(contents);
+                self.artifact
+                    .define(name, bytes)
+                    .expect("inconsistent declaration");
+            }
+        }
+
         Ok(FaerieCompiledData {})
     }
 

--- a/cranelift-faerie/src/backend.rs
+++ b/cranelift-faerie/src/backend.rs
@@ -242,21 +242,18 @@ impl Backend for FaerieBackend {
                 .map_err(|e| ModuleError::Backend(e.to_string()))?;
         }
 
-        let size = init.size();
-        let mut bytes = Vec::with_capacity(size);
         match *init {
             Init::Uninitialized => {
                 panic!("data is not initialized yet");
             }
-            Init::Zeros { .. } => {
+            Init::Zeros { size } => {
                 self.artifact
                     .define_zero_init(name, size)
                     .expect("inconsistent declaration");
             }
             Init::Bytes { ref contents } => {
-                bytes.extend_from_slice(contents);
                 self.artifact
-                    .define(name, bytes)
+                    .define(name, contents.to_vec())
                     .expect("inconsistent declaration");
             }
         }

--- a/cranelift-object/src/backend.rs
+++ b/cranelift-object/src/backend.rs
@@ -243,7 +243,6 @@ impl Backend for ObjectBackend {
             ref data_relocs,
         } = data_ctx.description();
 
-
         let reloc_size = match self.isa.triple().pointer_width().unwrap() {
             PointerWidth::U16 => 16,
             PointerWidth::U32 => 32,
@@ -288,11 +287,9 @@ impl Backend for ObjectBackend {
             Init::Uninitialized => {
                 panic!("data is not initialized yet");
             }
-            Init::Zeros { size } => {
-                use std::convert::TryInto;
-                let size = size.try_into().expect("usize > u64");
-                self.object.add_symbol_bss(symbol, section, size, align)
-            }
+            Init::Zeros { size } => self
+                .object
+                .add_symbol_bss(symbol, section, size as u64, align),
             Init::Bytes { ref contents } => self
                 .object
                 .add_symbol_data(symbol, section, &contents, align),

--- a/cranelift-object/src/backend.rs
+++ b/cranelift-object/src/backend.rs
@@ -273,13 +273,16 @@ impl Backend for ObjectBackend {
         }
 
         let symbol = self.data_objects[data_id].unwrap();
-        let section = self.object.section_id(if writable {
+        let section_kind = if let Init::Zeros { .. } = *init {
+            StandardSection::UninitializedData
+        } else if writable {
             StandardSection::Data
         } else if relocs.is_empty() {
             StandardSection::ReadOnlyData
         } else {
             StandardSection::ReadOnlyDataWithRel
-        });
+        };
+        let section = self.object.section_id(section_kind);
 
         let align = u64::from(align.unwrap_or(1));
         let offset = match *init {

--- a/cranelift-object/src/backend.rs
+++ b/cranelift-object/src/backend.rs
@@ -243,7 +243,6 @@ impl Backend for ObjectBackend {
             ref data_relocs,
         } = data_ctx.description();
 
-        let size = init.size();
 
         let reloc_size = match self.isa.triple().pointer_width().unwrap() {
             PointerWidth::U16 => 16,
@@ -289,7 +288,7 @@ impl Backend for ObjectBackend {
             Init::Uninitialized => {
                 panic!("data is not initialized yet");
             }
-            Init::Zeros { .. } => {
+            Init::Zeros { size } => {
                 use std::convert::TryInto;
                 let size = size.try_into().expect("usize > u64");
                 self.object.add_symbol_bss(symbol, section, size, align)

--- a/cranelift-object/src/backend.rs
+++ b/cranelift-object/src/backend.rs
@@ -294,9 +294,9 @@ impl Backend for ObjectBackend {
                 let size = size.try_into().expect("usize > u64");
                 self.object.add_symbol_bss(symbol, section, size, align)
             }
-            Init::Bytes { ref contents } => {
-                self.object.add_symbol_data(symbol, section, &contents, align)
-            }
+            Init::Bytes { ref contents } => self
+                .object
+                .add_symbol_data(symbol, section, &contents, align),
         };
         if !relocs.is_empty() {
             self.relocs.push(SymbolRelocs {


### PR DESCRIPTION
- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
This has not been discussed yet. Discussion of why this feature was implemented is in https://github.com/m4b/faerie/issues/97.

- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
This uses the new `zero_init` api for Faerie, which uses `.bss` sections to reduce the amount of space binaries take up in memory (while being generated) and on disk (when stored).

- [ ] This PR contains test cases, if meaningful.
This PR does not contain new test cases. All existing test cases pass.

- [ ] A reviewer from the core maintainer team has been assigned for this PR.
I am not sure who should review this.