### PR TITLE
Bind constant vectors to vconst; fixes #1052

### DIFF
--- a/filetests/isa/x86/legalize-splat.clif
+++ b/filetests/isa/x86/legalize-splat.clif
@@ -67,7 +67,6 @@ ebb0:
 ; nextln:     v2 = iconst.i32 42
 ; nextln:     v0 = ireduce.i8 v2
 ; nextln:     v3 = scalar_to_vector.i8x16 v0
-; nextln:     v4 = f64const 0.0
-; nextln:     v5 = raw_bitcast.i8x16 v4
-; nextln:     v1 = x86_pshufb v3, v5
+; nextln:     v4 = vconst.i8x16 0x00
+; nextln:     v1 = x86_pshufb v3, v4
 ; nextln:     return v1


### PR DESCRIPTION
- [x] This has been discussed in issue #1052
- [x] A short description of what this does, why it is needed: #1104 added the ability to create constants in the legalization AST; this change takes advantage of that to remove a weird `fconst + raw_bitcast` pattern.
- [x] This PR contains test cases, if meaningful.
- [x] A reviewer from the core maintainer team has been assigned for this PR.
