### PR TITLE
Add legalization for bitrev.i128 via narrowing, fixes #1116

### DIFF
--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -848,9 +848,9 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
         def!(a = bitrev.I128(x)),
         vec![
             def!((xl, xh) = isplit(x)),
-            def!(eh = bitrev(xl)),
-            def!(el = bitrev(xh)),
-            def!(a = iconcat(el, eh)),
+            def!(yh = bitrev(xl)),
+            def!(yl = bitrev(xh)),
+            def!(a = iconcat(yl, yh)),
         ],
     );
 

--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -844,6 +844,16 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
         ],
     );
 
+    narrow.legalize(
+        def!(a = bitrev.I128(x)),
+        vec![
+            def!((xl, xh) = isplit(x)),
+            def!(e1 = bitrev(xl)),
+            def!(e2 = bitrev(xh)),
+            def!(a = iconcat(e2, e1)),
+        ],
+    );
+
     // Floating-point sign manipulations.
     for &(ty, const_inst, minus_zero) in &[
         (F32, f32const, &Literal::bits(&imm.ieee32, 0x8000_0000)),

--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -848,9 +848,9 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
         def!(a = bitrev.I128(x)),
         vec![
             def!((xl, xh) = isplit(x)),
-            def!(e1 = bitrev(xl)),
-            def!(e2 = bitrev(xh)),
-            def!(a = iconcat(e2, e1)),
+            def!(eh = bitrev(xl)),
+            def!(el = bitrev(xh)),
+            def!(a = iconcat(el, eh)),
         ],
     );
 

--- a/filetests/isa/x86/bitrev-i128-run.clif
+++ b/filetests/isa/x86/bitrev-i128-run.clif
@@ -1,0 +1,46 @@
+test run
+target x86_64
+
+function %reverse_bits_zero() -> b1 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = iconcat v0, v0
+    v2 = bitrev.i128 v1
+    v3 = icmp eq v2, v1
+    return v3
+}
+; run
+
+function %reverse_bits_one() -> b1 {
+ebb0:
+    v0 = iconst.i64 0
+    v1 = iconst.i64 1
+    v2 = iconcat v0, v1
+
+    v3 = bitrev.i128 v2
+
+    v4 = iconst.i64 0x8000_0000_0000_0000
+    v5 = iconst.i64 0
+    v6 = iconcat v4, v5
+
+    v7 = icmp eq v3, v6
+    return v7
+}
+; run
+
+function %reverse_bits() -> b1 {
+ebb0:
+    v0 = iconst.i64 0x06AD_8667_69EC_41BA
+    v1 = iconst.i64 0x6C83_D81A_6E28_83AB
+    v2 = iconcat v0, v1
+
+    v3 = bitrev.i128 v2
+
+    v4 = iconst.i64 0xD5C11476581BC136
+    v5 = iconst.i64 0x5D823796E661B560
+    v6 = iconcat v4, v5
+
+    v7 = icmp eq v3, v6
+    return v7
+}
+; run

--- a/filetests/legalizer/bitrev-i128.clif
+++ b/filetests/legalizer/bitrev-i128.clif
@@ -1,0 +1,89 @@
+test legalizer
+target x86_64
+
+function %reverse_bits(i128) -> i128 {
+ebb0(v0: i128):
+    v1 = bitrev.i128 v0
+    return v1
+}
+
+; check: ebb0(v2: i64, v3: i64):
+; check: v0 = iconcat v2, v3
+; check: v33 = iconst.i64 0xaaaa_aaaa_aaaa_aaaa
+; check: v6 = band v2, v33
+; check: v7 = ushr_imm v6, 1
+; check: v34 = iconst.i64 0x5555_5555_5555_5555
+; check: v8 = band v2, v34
+; check: v9 = ishl_imm v8, 1
+; check: v10 = bor v7, v9
+; check: v35 = iconst.i64 0xcccc_cccc_cccc_cccc
+; check: v11 = band v10, v35
+; check: v12 = ushr_imm v11, 2
+; check: v36 = iconst.i64 0x3333_3333_3333_3333
+; check: v13 = band v10, v36
+; check: v14 = ishl_imm v13, 2
+; check: v15 = bor v12, v14
+; check: v37 = iconst.i64 0xf0f0_f0f0_f0f0_f0f0
+; check: v16 = band v15, v37
+; check: v17 = ushr_imm v16, 4
+; check: v38 = iconst.i64 0x0f0f_0f0f_0f0f_0f0f
+; check: v18 = band v15, v38
+; check: v19 = ishl_imm v18, 4
+; check: v20 = bor v17, v19
+; check: v39 = iconst.i64 0xff00_ff00_ff00_ff00
+; check: v21 = band v20, v39
+; check: v22 = ushr_imm v21, 8
+; check: v40 = iconst.i64 0x00ff_00ff_00ff_00ff
+; check: v23 = band v20, v40
+; check: v24 = ishl_imm v23, 8
+; check: v25 = bor v22, v24
+; check: v41 = iconst.i64 0xffff_0000_ffff_0000
+; check: v26 = band v25, v41
+; check: v27 = ushr_imm v26, 16
+; check: v42 = iconst.i64 0xffff_0000_ffff
+; check: v28 = band v25, v42
+; check: v29 = ishl_imm v28, 16
+; check: v30 = bor v27, v29
+; check: v31 = ushr_imm v30, 32
+; check: v32 = ishl_imm v30, 32
+; check: v4 = bor v31, v32
+; check: v70 = iconst.i64 0xaaaa_aaaa_aaaa_aaaa
+; check: v43 = band v3, v70
+; check: v44 = ushr_imm v43, 1
+; check: v71 = iconst.i64 0x5555_5555_5555_5555
+; check: v45 = band v3, v71
+; check: v46 = ishl_imm v45, 1
+; check: v47 = bor v44, v46
+; check: v72 = iconst.i64 0xcccc_cccc_cccc_cccc
+; check: v48 = band v47, v72
+; check: v49 = ushr_imm v48, 2
+; check: v73 = iconst.i64 0x3333_3333_3333_3333
+; check: v50 = band v47, v73
+; check: v51 = ishl_imm v50, 2
+; check: v52 = bor v49, v51
+; check: v74 = iconst.i64 0xf0f0_f0f0_f0f0_f0f0
+; check: v53 = band v52, v74
+; check: v54 = ushr_imm v53, 4
+; check: v75 = iconst.i64 0x0f0f_0f0f_0f0f_0f0f
+; check: v55 = band v52, v75
+; check: v56 = ishl_imm v55, 4
+; check: v57 = bor v54, v56
+; check: v76 = iconst.i64 0xff00_ff00_ff00_ff00
+; check: v58 = band v57, v76
+; check: v59 = ushr_imm v58, 8
+; check: v77 = iconst.i64 0x00ff_00ff_00ff_00ff
+; check: v60 = band v57, v77
+; check: v61 = ishl_imm v60, 8
+; check: v62 = bor v59, v61
+; check: v78 = iconst.i64 0xffff_0000_ffff_0000
+; check: v63 = band v62, v78
+; check: v64 = ushr_imm v63, 16
+; check: v79 = iconst.i64 0xffff_0000_ffff
+; check: v65 = band v62, v79
+; check: v66 = ishl_imm v65, 16
+; check: v67 = bor v64, v66
+; check: v68 = ushr_imm v67, 32
+; check: v69 = ishl_imm v67, 32
+; check: v5 = bor v68, v69
+; check: v1 = iconcat v5, v4
+; check: return v5, v4


### PR DESCRIPTION
This PR lowers bitrev.i128 by narrowing it to two bitrev.i64 instructions and an addition.

ping @bnjbvr 