### PR TITLE
Fix rendered links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,9 +50,9 @@ things set in stone yet.
 
 Cranelift is a [Bytecode Alliance] project, and follows the Bytecode Alliance's [Code of Conduct] and [Organizational Code of Conduct].
 
-[Bytecode Alliance] : https://bytecodealliance.org/
-[Code of Conduct] : CODE_OF_CONDUCT.md
-[Organizational Code of Conduct] : ORG_CODE_OF_CONDUCT.md
+[Bytecode Alliance]: https://bytecodealliance.org/
+[Code of Conduct]: CODE_OF_CONDUCT.md
+[Organizational Code of Conduct]: ORG_CODE_OF_CONDUCT.md
 
 ## Coding Guidelines
 


### PR DESCRIPTION
Currently these links aren't rendered because of the extra space.