### PR TITLE
Print VerifierErrors in Display for CodegenResult

### DIFF
--- a/cranelift-codegen/src/result.rs
+++ b/cranelift-codegen/src/result.rs
@@ -12,7 +12,7 @@ pub enum CodegenError {
     ///
     /// This always represents a bug, either in the code that generated IR for Cranelift, or a bug
     /// in Cranelift itself.
-    #[error("Verifier errors")]
+    #[error("Verifier errors:\n{0}")]
     Verifier(#[from] VerifierErrors),
 
     /// An implementation limit was exceeded.


### PR DESCRIPTION
- [x] This has been discussed in issue #..., or if not, please tell us why
  here.
This fixes a regression in Cranelift.
- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
These error messages seem to have gotten lost in the switch to `thiseerror`
(https://github.com/bytecodealliance/cranelift/commit/d23030f7f5ce75a89b31f260c9ea893530f0124a#diff-55f6fffe972a2ad7efb7edd56cb29afcR15)

That change made it very hard to debug bad generated code.
This change prints the message again.

Before: `Verifier errors`
After:
```
Verifier errors:
- inst16: Branch must have an encoding
```

- [ ] This PR contains test cases, if meaningful.
N/A
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.
I am not sure who should review this @bnjbvr.