### PR TITLE
Revert some links back to Cranestation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ documentation](https://cranelift.readthedocs.io/en/latest/?badge=latest).
 For an example of how to use the JIT, see the [SimpleJIT Demo], which
 implements a toy language.
 
-[SimpleJIT Demo]: https://github.com/bytecodealliance/simplejit-demo
+[SimpleJIT Demo]: https://github.com/Cranestation/simplejit-demo
 
 For an example of how to use Cranelift to run WebAssembly code, see
 [Wasmtime], which implements a standalone, embeddable, VM using Cranelift.
@@ -173,4 +173,4 @@ Editor Support
 
 Editor support for working with Cranelift IR (clif) files:
 
- - Vim: https://github.com/bytecodealliance/cranelift.vim
+ - Vim: https://github.com/Cranestation/cranelift.vim

--- a/README.md
+++ b/README.md
@@ -173,4 +173,4 @@ Editor Support
 
 Editor support for working with Cranelift IR (clif) files:
 
- - Vim: https://github.com/Cranestation/cranelift.vim
+ - Vim: https://github.com/bytecodealliance/cranelift.vim


### PR DESCRIPTION
Fixes #1241

- [x] This has been discussed in issue #1241, or if not, please tell us why
  here.
- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first. The link to some projects which havent been moved to bytecodealliance were accidentially changed. This PR changes them back.
- [ ] This PR contains test cases, if meaningful. N/A
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.

<!-- Please ensure all communication adheres to the [code of
conduct](https://github.com/CraneStation/cranelift/blob/master/CODE_OF_CONDUCT.md). -->
