### PR TITLE
Add X128 type to represent WebAssembly's V128 type

### DIFF
--- a/cranelift-codegen/src/verifier/mod.rs
+++ b/cranelift-codegen/src/verifier/mod.rs
@@ -1257,7 +1257,7 @@ impl<'a> Verifier<'a> {
             let arg_type = self.func.dfg.value_type(arg);
             match constraints.value_argument_constraint(i, ctrl_type) {
                 ResolvedConstraint::Bound(expected_type) => {
-                    if arg_type != expected_type {
+                    if arg_type != expected_type && !expected_type.is_subtype_of(arg_type) {
                         report!(
                             errors,
                             inst,
@@ -1484,7 +1484,9 @@ impl<'a> Verifier<'a> {
             }
             for (i, (&arg, &expected_type)) in args.iter().zip(expected_types).enumerate() {
                 let arg_type = self.func.dfg.value_type(arg);
-                if arg_type != expected_type.value_type {
+                if arg_type != expected_type.value_type
+                    && !arg_type.is_subtype_of(expected_type.value_type)
+                {
                     report!(
                         errors,
                         inst,

--- a/cranelift-reader/src/lexer.rs
+++ b/cranelift-reader/src/lexer.rs
@@ -328,6 +328,7 @@ impl<'a> Lexer<'a> {
                 .unwrap_or_else(|| match text {
                     "iflags" => Token::Type(types::IFLAGS),
                     "fflags" => Token::Type(types::FFLAGS),
+                    "x128" => Token::Type(types::X128),
                     _ => Token::Identifier(text),
                 }),
             loc,

--- a/filetests/verifier/simd-x128-type.clif
+++ b/filetests/verifier/simd-x128-type.clif
@@ -1,0 +1,31 @@
+test verifier
+set enable_simd
+target x86_64
+
+; This file tests using x128 as a default type to represent Wasm's V128 type. Values of Wasm's V128
+; type can be used in any instruction of similar width (e.g. `i32x4.add`). Cranelift must build
+; signatures for Wasm functions using V128 (x128 here to avoid lexing issues with values).
+
+function %passes_non_default_type(i32x4) {
+ebb0(v0: i32x4):
+    v1 = fneg.f32x4 v0 ; error: arg 0 (v0) has type i32x4, expected f32x4
+    return
+}
+
+function %passes_default_type(x128) {
+ebb0(v0: x128):
+    v1 = fadd.f32x4 v0, v0
+    return
+}
+
+function %returns_non_default_type() -> i64x2 {
+ebb0:
+    v1 = vconst.i32x4 [0 1 2 3]
+    return v1 ; error: arg 0 (v1) has type i32x4, must match function signature of i64x2
+}
+
+function %returns_default_type() -> x128 {
+ebb0:
+    v1 = vconst.i32x4 [0 1 2 3]
+    return v1
+}


### PR DESCRIPTION
WebAssembly has a generic 128-bit wide type that can be used in any SIMD operation (e.g., `i32x4.add`). Cranelift's type system is more strict (i.e., only an I32X4 value can be used for an `i32x4.add`). To avoid many bitcasts when translating WebAssembly's SIMD operations, we add the X128 type which acts as a super-type for all 128-bit wide types.

- [x] This has been discussed in a previous issue:

The original problem is described at #1192 and an alternate implementation at #1236 (it relaxes the verifier and uses `I8X16` as a default stand-in type for `V128`).

- [x] A short description of what this does, why it is needed:

This adds a new type `X128` to act as a super type for 128-bit wide vector types.

- [x] This PR contains test cases, if meaningful.
- [x] A reviewer from the core maintainer team has been assigned for this PR.