### PR TITLE
Use a published version of `object`

### DIFF
--- a/cranelift-object/Cargo.toml
+++ b/cranelift-object/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 cranelift-module = { path = "../cranelift-module", version = "0.51.0" }
-object = { git = "https://github.com/gimli-rs/object", rev = "cba3ed4932e4c594c5eab4f5ef6c51838f4a5056", default-features = false, features = ["write"] }
+object = { version = "0.16", default-features = false, features = ["write"] }
 target-lexicon = "0.9"
 
 [dependencies.cranelift-codegen]

--- a/publish-all.sh
+++ b/publish-all.sh
@@ -43,7 +43,7 @@ for crate in \
     entity bforest codegen/shared codegen/meta codegen frontend native \
     preopt \
     reader wasm module \
-    faerie umbrella simplejit
+    faerie umbrella simplejit object
 do
     echo cargo publish --manifest-path "cranelift-$crate/Cargo.toml"
 


### PR DESCRIPTION
- [x] This has been discussed in issue #1254
- [x] This allows publishing `cranelift-object` since it no longer depends on
a git version of a dependency.
- [ ] This PR contains test cases, if meaningful.
N/A

- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.
I think @philipc  would be best able to review this, but I do not know if he is a member of the core team.