### PR TITLE
Add hooks for implementing bulk-memory-operations

### DIFF
--- a/cranelift-wasm/src/environ/dummy.rs
+++ b/cranelift-wasm/src/environ/dummy.rs
@@ -413,15 +413,22 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         Ok(())
     }
 
-    fn translate_table_size(&mut self, mut pos: FuncCursor, _index: u32) -> WasmResult<ir::Value> {
+    fn translate_table_size(
+        &mut self,
+        mut pos: FuncCursor,
+        _index: TableIndex,
+        _table: ir::Table,
+    ) -> WasmResult<ir::Value> {
         Ok(pos.ins().iconst(I32, -1))
     }
 
     fn translate_table_copy(
         &mut self,
         _pos: FuncCursor,
-        _dest_index: u32,
-        _src_index: u32,
+        _dst_index: TableIndex,
+        _dst_table: ir::Table,
+        _src_index: TableIndex,
+        _src_table: ir::Table,
         _dst: ir::Value,
         _src: ir::Value,
         _len: ir::Value,
@@ -433,7 +440,8 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         &mut self,
         _pos: FuncCursor,
         _seg_index: u32,
-        _table_index: u32,
+        _table_index: TableIndex,
+        _table: ir::Table,
         _dst: ir::Value,
         _src: ir::Value,
         _len: ir::Value,

--- a/cranelift-wasm/src/environ/dummy.rs
+++ b/cranelift-wasm/src/environ/dummy.rs
@@ -371,6 +371,79 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
     ) -> WasmResult<ir::Value> {
         Ok(pos.ins().iconst(I32, -1))
     }
+
+    fn translate_memory_copy(
+        &mut self,
+        _pos: FuncCursor,
+        _index: MemoryIndex,
+        _heap: ir::Heap,
+        _dst: ir::Value,
+        _src: ir::Value,
+        _len: ir::Value,
+    ) -> WasmResult<()> {
+        Ok(())
+    }
+
+    fn translate_memory_fill(
+        &mut self,
+        _pos: FuncCursor,
+        _index: MemoryIndex,
+        _heap: ir::Heap,
+        _dst: ir::Value,
+        _val: ir::Value,
+        _len: ir::Value,
+    ) -> WasmResult<()> {
+        Ok(())
+    }
+
+    fn translate_memory_init(
+        &mut self,
+        _pos: FuncCursor,
+        _index: MemoryIndex,
+        _heap: ir::Heap,
+        _seg_index: u32,
+        _dst: ir::Value,
+        _src: ir::Value,
+        _len: ir::Value,
+    ) -> WasmResult<()> {
+        Ok(())
+    }
+
+    fn translate_data_drop(&mut self, _pos: FuncCursor, _seg_index: u32) -> WasmResult<()> {
+        Ok(())
+    }
+
+    fn translate_table_size(&mut self, mut pos: FuncCursor, _index: u32) -> WasmResult<ir::Value> {
+        Ok(pos.ins().iconst(I32, -1))
+    }
+
+    fn translate_table_copy(
+        &mut self,
+        _pos: FuncCursor,
+        _dest_index: u32,
+        _src_index: u32,
+        _dst: ir::Value,
+        _src: ir::Value,
+        _len: ir::Value,
+    ) -> WasmResult<()> {
+        Ok(())
+    }
+
+    fn translate_table_init(
+        &mut self,
+        _pos: FuncCursor,
+        _seg_index: u32,
+        _table_index: u32,
+        _dst: ir::Value,
+        _src: ir::Value,
+        _len: ir::Value,
+    ) -> WasmResult<()> {
+        Ok(())
+    }
+
+    fn translate_elem_drop(&mut self, _pos: FuncCursor, _seg_index: u32) -> WasmResult<()> {
+        Ok(())
+    }
 }
 
 impl<'data> ModuleEnvironment<'data> for DummyEnvironment {

--- a/cranelift-wasm/src/environ/spec.rs
+++ b/cranelift-wasm/src/environ/spec.rs
@@ -266,6 +266,81 @@ pub trait FuncEnvironment {
         heap: ir::Heap,
     ) -> WasmResult<ir::Value>;
 
+    /// Translate a `memory.copy` WebAssembly instruction.
+    ///
+    /// The `index` provided identifies the linear memory to query, and `heap` is the heap reference
+    /// returned by `make_heap` for the same index.
+    fn translate_memory_copy(
+        &mut self,
+        pos: FuncCursor,
+        index: MemoryIndex,
+        heap: ir::Heap,
+        dst: ir::Value,
+        src: ir::Value,
+        len: ir::Value,
+    ) -> WasmResult<()>;
+
+    /// Translate a `memory.fill` WebAssembly instruction.
+    ///
+    /// The `index` provided identifies the linear memory to query, and `heap` is the heap reference
+    /// returned by `make_heap` for the same index.
+    fn translate_memory_fill(
+        &mut self,
+        pos: FuncCursor,
+        index: MemoryIndex,
+        heap: ir::Heap,
+        dst: ir::Value,
+        val: ir::Value,
+        len: ir::Value,
+    ) -> WasmResult<()>;
+
+    /// Translate a `memory.init` WebAssembly instruction.
+    ///
+    /// The `index` provided identifies the linear memory to query, and `heap` is the heap reference
+    /// returned by `make_heap` for the same index. `seg_index` is the index of the segment to copy
+    /// from.
+    fn translate_memory_init(
+        &mut self,
+        pos: FuncCursor,
+        index: MemoryIndex,
+        heap: ir::Heap,
+        seg_index: u32,
+        dst: ir::Value,
+        src: ir::Value,
+        len: ir::Value,
+    ) -> WasmResult<()>;
+
+    /// Translate a `data.drop` WebAssembly instruction.
+    fn translate_data_drop(&mut self, pos: FuncCursor, seg_index: u32) -> WasmResult<()>;
+
+    /// Translate a `table.size` WebAssembly instruction.
+    fn translate_table_size(&mut self, pos: FuncCursor, index: u32) -> WasmResult<ir::Value>;
+
+    /// Translate a `table.copy` WebAssembly instruction.
+    fn translate_table_copy(
+        &mut self,
+        pos: FuncCursor,
+        dest_index: u32,
+        src_index: u32,
+        dst: ir::Value,
+        src: ir::Value,
+        len: ir::Value,
+    ) -> WasmResult<()>;
+
+    /// Translate a `table.init` WebAssembly instruction.
+    fn translate_table_init(
+        &mut self,
+        pos: FuncCursor,
+        seg_index: u32,
+        table_index: u32,
+        dst: ir::Value,
+        src: ir::Value,
+        len: ir::Value,
+    ) -> WasmResult<()>;
+
+    /// Translate a `elem.drop` WebAssembly instruction.
+    fn translate_elem_drop(&mut self, pos: FuncCursor, seg_index: u32) -> WasmResult<()>;
+
     /// Emit code at the beginning of every wasm loop.
     ///
     /// This can be used to insert explicit interrupt or safepoint checking at

--- a/cranelift-wasm/src/environ/spec.rs
+++ b/cranelift-wasm/src/environ/spec.rs
@@ -314,14 +314,21 @@ pub trait FuncEnvironment {
     fn translate_data_drop(&mut self, pos: FuncCursor, seg_index: u32) -> WasmResult<()>;
 
     /// Translate a `table.size` WebAssembly instruction.
-    fn translate_table_size(&mut self, pos: FuncCursor, index: u32) -> WasmResult<ir::Value>;
+    fn translate_table_size(
+        &mut self,
+        pos: FuncCursor,
+        index: TableIndex,
+        table: ir::Table,
+    ) -> WasmResult<ir::Value>;
 
     /// Translate a `table.copy` WebAssembly instruction.
     fn translate_table_copy(
         &mut self,
         pos: FuncCursor,
-        dest_index: u32,
-        src_index: u32,
+        dst_table_index: TableIndex,
+        dst_table: ir::Table,
+        src_table_index: TableIndex,
+        src_table: ir::Table,
         dst: ir::Value,
         src: ir::Value,
         len: ir::Value,
@@ -332,7 +339,8 @@ pub trait FuncEnvironment {
         &mut self,
         pos: FuncCursor,
         seg_index: u32,
-        table_index: u32,
+        table_index: TableIndex,
+        table: ir::Table,
         dst: ir::Value,
         src: ir::Value,
         len: ir::Value,


### PR DESCRIPTION
I have patches that add support for bulk-memory-operations in SpiderMonkey with Cranelift. These commits are the prerequisites for those patches.

The only major change is adding extensibility points to cranelift-wasm for translating bulk-memory-operations. These will be used in SM to translate the operations into function calls which will do the actual work.