### PR TITLE
Fix jump table comment grammar

### DIFF
--- a/cranelift-codegen/src/ir/jumptable.rs
+++ b/cranelift-codegen/src/ir/jumptable.rs
@@ -10,7 +10,7 @@ use core::slice::{Iter, IterMut};
 
 /// Contents of a jump table.
 ///
-/// All jump tables use 0-based indexing and densely populated.
+/// All jump tables use 0-based indexing and are densely populated.
 #[derive(Clone)]
 pub struct JumpTableData {
     // Table entries.


### PR DESCRIPTION
- [x] This has been discussed in issue #..., or if not, please tell us why
  here.
   This is a small patch, no code change.
- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
  Fix a small grammar mishap in the documentation comment for `JumpTableData`.
- [x] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.

<!-- Please ensure all communication adheres to the [code of
conduct](https://github.com/CraneStation/cranelift/blob/master/CODE_OF_CONDUCT.md). -->

Found this while looking into how jump tables are emitted, figured it was worth a small PR :slightly_smiling_face: 