### PR TITLE
Partially fix no_std build for cratelift-codegen

### DIFF
--- a/cranelift-codegen/shared/src/condcodes.rs
+++ b/cranelift-codegen/shared/src/condcodes.rs
@@ -313,7 +313,7 @@ impl FromStr for FloatCC {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     static INT_ALL: [IntCC; 12] = [
         IntCC::Equal,

--- a/cranelift-codegen/shared/src/constant_hash.rs
+++ b/cranelift-codegen/shared/src/constant_hash.rs
@@ -10,7 +10,8 @@
 //! This module provides build meta support for lookups in these tables, as well as the shared hash
 //! function used for probing.
 
-use std::iter;
+use alloc::vec::Vec;
+use core::iter;
 
 /// A primitive hash function for matching opcodes.
 pub fn simple_hash(s: &str) -> usize {
@@ -57,6 +58,7 @@ pub fn generate_table<'cont, T, I: iter::Iterator<Item = &'cont T>, H: Fn(&T) ->
 #[cfg(test)]
 mod tests {
     use super::{generate_table, simple_hash};
+    use alloc::string::ToString;
 
     #[test]
     fn basic() {

--- a/cranelift-codegen/shared/src/isa/x86/encoding_bits.rs
+++ b/cranelift-codegen/shared/src/isa/x86/encoding_bits.rs
@@ -1,6 +1,6 @@
 //! Provides a named interface to the `u16` Encoding bits.
 
-use std::ops::RangeInclusive;
+use core::ops::RangeInclusive;
 
 /// Named interface to the `u16` Encoding bits, representing an opcode.
 ///

--- a/cranelift-codegen/shared/src/lib.rs
+++ b/cranelift-codegen/shared/src/lib.rs
@@ -19,6 +19,11 @@
         clippy::use_self
     )
 )]
+#![no_std]
+
+#[allow(unused_imports)] // #[macro_use] is required for no_std
+#[macro_use]
+extern crate alloc;
 
 pub mod condcodes;
 pub mod constant_hash;

--- a/cranelift-codegen/src/ir/framelayout.rs
+++ b/cranelift-codegen/src/ir/framelayout.rs
@@ -2,7 +2,7 @@
 
 use crate::ir::entities::Inst;
 use crate::isa::RegUnit;
-use std::boxed::Box;
+use alloc::boxed::Box;
 
 use crate::HashMap;
 

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -18,9 +18,9 @@ use crate::regalloc::RegisterSet;
 use crate::result::CodegenResult;
 use crate::stack_layout::layout_stack;
 use alloc::borrow::Cow;
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::i32;
-use std::boxed::Box;
 use target_lexicon::{PointerWidth, Triple};
 
 /// Argument registers for x86-64
@@ -940,7 +940,7 @@ fn insert_common_epilogue(
                 *insts = insts
                     .iter()
                     .cloned()
-                    .chain(std::iter::once(new_cfa))
+                    .chain(core::iter::once(new_cfa))
                     .collect::<Box<[_]>>();
             })
             .or_insert_with(|| Box::new([new_cfa]));

--- a/cranelift-codegen/src/legalizer/boundary.rs
+++ b/cranelift-codegen/src/legalizer/boundary.rs
@@ -701,7 +701,7 @@ fn legalize_inst_arguments<ArgType>(
 /// will go into the `sret` space.
 fn legalized_type_for_sret(ty: Type) -> Type {
     if ty.is_bool() {
-        let bits = std::cmp::max(8, ty.bits());
+        let bits = core::cmp::max(8, ty.bits());
         Type::int(bits).unwrap()
     } else {
         ty
@@ -713,7 +713,7 @@ fn legalized_type_for_sret(ty: Type) -> Type {
 /// unmodified) legalized value and its type.
 fn legalize_type_for_sret_store(pos: &mut FuncCursor, val: Value, ty: Type) -> (Value, Type) {
     if ty.is_bool() {
-        let bits = std::cmp::max(8, ty.bits());
+        let bits = core::cmp::max(8, ty.bits());
         let ty = Type::int(bits).unwrap();
         let val = pos.ins().bint(ty, val);
         (val, ty)


### PR DESCRIPTION
* Add a feature gate for the std feature in `packed_struct`
* Replace a few std references with core and alloc

See #1261 for more info. I'm intentionally avoiding the use of an issue keyword here, because this PR only fixes points 1 and 2 in that issue.

@bnjbvr The placeholder text says to ping you if I don't know who can review this, and it doesn't look like I can assign a reviewer at all, so here you go.