### PR TITLE
Update build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ into executable machine code.
 
 [BA]: https://bytecodealliance.org/
 [![Documentation Status](https://readthedocs.org/projects/cranelift/badge/?version=latest)](https://cranelift.readthedocs.io/en/latest/?badge=latest)
-[![Travis Status](https://travis-ci.org/bytecodealliance/cranelift.svg?branch=master)](https://travis-ci.org/bytecodealliance/cranelift)
+[![Build Status](https://github.com/bytecodealliance/cranelift/workflows/CI/badge.svg)](https://github.com/bytecodealliance/cranelift/actions)
 [![Fuzzit Status](https://app.fuzzit.dev/badge?org_id=bytecodealliance)](https://app.fuzzit.dev/orgs/bytecodealliance/dashboard)
 [![Gitter chat](https://badges.gitter.im/bytecodealliance/bytecodealliance.svg)](https://gitter.im/CraneStation/Lobby)
 ![Minimum rustc 1.37](https://img.shields.io/badge/rustc-1.37+-green.svg)


### PR DESCRIPTION
- [x] This has not been discussed in an issue.
- [x] A short description of what this does, why it is needed: see title.
- [x] This PR contains no test cases.
- [x] A reviewer from the core maintainer team has been assigned for this PR.

It occurred to me that perhaps we would also like to update the docs badge to something like 
```
[![Documentation Status](https://docs.rs/cranelift/badge.svg)](https://docs.rs/cranelift)
```
[![Documentation Status](https://docs.rs/cranelift/badge.svg)](https://docs.rs/cranelift)

I did not include this change in this commit, however, becaue it involves some decision-making about if and when the readthedocs documentation should be abandoned. I seem to remember some discussion on this but cannot recall the issue.

