### PR TITLE
Sort the generated list of instruction formats by name

### DIFF
--- a/cranelift-codegen/meta/src/shared/mod.rs
+++ b/cranelift-codegen/meta/src/shared/mod.rs
@@ -92,6 +92,8 @@ impl Definitions {
             }
         }
 
-        Vec::from_iter(format_structures.into_iter().map(|(_, v)| v))
+        let mut result = Vec::from_iter(format_structures.into_iter().map(|(_, v)| v));
+        result.sort_by_key(|format| format.name);
+        result
     }
 }


### PR DESCRIPTION
This makes opcodes.rs and inst_builders.rs deterministic, fixing bad cache miss behavior for build tools like [sccache](https://github.com/mozilla/sccache), see also [this Bugzilla issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1601150).

Thanks to @glandium who wrote the original commit in spirit; I've tweaked the code to use `sort_by_key` instead of `sort_by`, to make it more idiomatic.

To make sure there was no other deterministic issue, I've ran the build script once and saved the output into a given directory, then re-ran the build script a hundred times, each time comparing the output with the one from the first run. There were no differences after this, so we *should* be good (with a very low probability of being wrong). It might be worth adding a script to do so in automation, in the future, and to run it on one target.