### PR TITLE
Ensure builds are deterministic in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,6 +112,18 @@ jobs:
       if: false && matrix.rust == 'nightly' # Temporarily disable fuzz tests until https://github.com/bytecodealliance/cranelift/issues/1216 is resolved
       continue-on-error: true
 
+  meta_determinist_check:
+    name: Meta deterministic check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Install Rust
+      run: rustup update stable && rustup default stable
+    - run: cargo build
+    - run: ci/ensure_deterministic_build.sh
+
   fuzz:
     name: Fuzz Regression
     runs-on: ubuntu-latest

--- a/ci/ensure_deterministic_build.sh
+++ b/ci/ensure_deterministic_build.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# This script makes sure that the meta crate deterministically generate files
+# with a high probability.
+# The current directory must be set to the repository's root.
+
+set -e
+
+BUILD_SCRIPT=$(find -wholename "./target/debug/build/cranelift-codegen-*/build-script-build")
+
+# First, run the script to generate a reference comparison.
+rm -rf /tmp/reference
+mkdir /tmp/reference
+OUT_DIR=/tmp/reference TARGET=x86_64 $BUILD_SCRIPT
+
+# To make sure the build script doesn't depend on the current directory, we'll
+# change the current working directory on every iteration. Make this easy to
+# reproduce this locally by first copying the target/ directory into an initial
+# temporary directory (and not move and lose the local clone's content).
+rm -rf /tmp/src0
+mkdir /tmp/src0
+
+echo Copying target directory...
+cp -r ./target /tmp/src0/target
+cd /tmp/src0
+echo "Done, starting loop."
+
+# Then, repeatedly make sure that the output is the same.
+for i in {1..20}
+do
+    # Move to a different directory, as explained above.
+    rm -rf /tmp/src$i
+    mkdir /tmp/src$i
+    mv ./* /tmp/src$i
+    cd /tmp/src$i
+
+    rm -rf /tmp/try
+    mkdir /tmp/try
+    OUT_DIR=/tmp/try TARGET=x86_64 $BUILD_SCRIPT
+    diff -qr /tmp/reference /tmp/try
+done


### PR DESCRIPTION
Not discussed in an issue, but this has happened enough times that it would be nice to address once and for all.

This introduces a script that has a high probability of failing if the
Rust source code generated by the meta crate is not consistent accross
build script runs.

It also adds a new CI job to run it on each push, on a single platform.