### PR TITLE
Bitcasting at control flow exits

### DIFF
--- a/cranelift-codegen/src/ir/dfg.rs
+++ b/cranelift-codegen/src/ir/dfg.rs
@@ -14,6 +14,7 @@ use crate::isa::TargetIsa;
 use crate::packed_option::ReservedValue;
 use crate::write::write_operands;
 use crate::HashMap;
+use alloc::vec::Vec;
 use core::fmt;
 use core::iter;
 use core::mem;
@@ -774,6 +775,14 @@ impl DataFlowGraph {
     /// Get the parameters on `ebb`.
     pub fn ebb_params(&self, ebb: Ebb) -> &[Value] {
         self.ebbs[ebb].params.as_slice(&self.value_lists)
+    }
+
+    /// Get the types of the parameters on `ebb`.
+    pub fn ebb_param_types(&self, ebb: Ebb) -> Vec<Type> {
+        self.ebb_params(ebb)
+            .iter()
+            .map(|&v| self.value_type(v))
+            .collect()
     }
 
     /// Append a parameter with type `ty` to `ebb`.

--- a/cranelift-codegen/src/ir/extfunc.rs
+++ b/cranelift-codegen/src/ir/extfunc.rs
@@ -88,6 +88,16 @@ impl Signature {
             .count()
     }
 
+    /// Count the number of normal parameters in a signature.
+    /// Exclude special-purpose parameters that represent runtime stuff and not WebAssembly
+    /// arguments.
+    pub fn num_normal_params(&self) -> usize {
+        self.params
+            .iter()
+            .filter(|arg| arg.purpose == ArgumentPurpose::Normal)
+            .count()
+    }
+
     /// Does this signature take an struct return pointer parameter?
     pub fn uses_struct_return_param(&self) -> bool {
         self.uses_special_param(ArgumentPurpose::StructReturn)

--- a/cranelift-codegen/src/ir/extfunc.rs
+++ b/cranelift-codegen/src/ir/extfunc.rs
@@ -102,6 +102,11 @@ impl Signature {
             .count()
             > 1
     }
+
+    /// Collect the return types of the signature.
+    pub fn return_types(&self) -> Vec<Type> {
+        self.returns.iter().map(|ap| ap.value_type).collect()
+    }
 }
 
 /// Wrapper type capable of displaying a `Signature` with correct register names.

--- a/cranelift-codegen/src/ir/extfunc.rs
+++ b/cranelift-codegen/src/ir/extfunc.rs
@@ -103,9 +103,22 @@ impl Signature {
             > 1
     }
 
-    /// Collect the return types of the signature.
+    /// Collect the normal parameter types of the signature; see `[ArgumentPurpose::Normal]`.
+    pub fn param_types(&self) -> Vec<Type> {
+        self.params
+            .iter()
+            .filter(|ap| ap.purpose == ArgumentPurpose::Normal)
+            .map(|ap| ap.value_type)
+            .collect()
+    }
+
+    /// Collect the normal return types of the signature; see `[ArgumentPurpose::Normal]`.
     pub fn return_types(&self) -> Vec<Type> {
-        self.returns.iter().map(|ap| ap.value_type).collect()
+        self.returns
+            .iter()
+            .filter(|ap| ap.purpose == ArgumentPurpose::Normal)
+            .map(|ap| ap.value_type)
+            .collect()
     }
 }
 

--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -414,7 +414,17 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                         frame.set_branched_to_exit();
                         frame.br_destination()
                     };
-                    builder.ins().jump(real_dest_ebb, state.peekn(return_count));
+
+                    // Bitcast any vector arguments to their default type, I8X16, before jumping.
+                    let destination_args = state.peekn_mut(return_count);
+                    let destination_types = builder.func.dfg.ebb_param_types(real_dest_ebb);
+                    bitcast_arguments(
+                        destination_args,
+                        &destination_types[..return_count],
+                        builder,
+                    );
+
+                    builder.ins().jump(real_dest_ebb, destination_args);
                 }
                 state.popn(return_count);
             }

--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -426,11 +426,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             };
             {
                 let return_args = state.peekn_mut(return_count);
-                let return_params = &builder.func.signature.returns;
-                let return_types = return_params
-                    .iter()
-                    .map(|ap| ap.value_type)
-                    .collect::<Vec<Type>>();
+                let return_types = &builder.func.signature.return_types();
                 bitcast_arguments(return_args, &return_types, builder);
                 match environ.return_mode() {
                     ReturnMode::NormalReturns => builder.ins().return_(return_args),

--- a/cranelift-wasm/src/func_translator.rs
+++ b/cranelift-wasm/src/func_translator.rs
@@ -10,11 +10,10 @@ use crate::state::{FuncTranslationState, ModuleTranslationState};
 use crate::translation_utils::get_vmctx_value_label;
 use crate::wasm_unsupported;
 use cranelift_codegen::entity::EntityRef;
-use cranelift_codegen::ir::{self, Ebb, InstBuilder, Type, ValueLabel};
+use cranelift_codegen::ir::{self, Ebb, InstBuilder, ValueLabel};
 use cranelift_codegen::timing;
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
 use log::info;
-use std::vec::Vec;
 use wasmparser::{self, BinaryReader};
 
 /// WebAssembly to Cranelift IR function translator.
@@ -242,11 +241,7 @@ fn parse_function_body<FE: FuncEnvironment + ?Sized>(
         if !builder.is_unreachable() {
             match environ.return_mode() {
                 ReturnMode::NormalReturns => {
-                    let return_params = &builder.func.signature.returns;
-                    let return_types = return_params
-                        .iter()
-                        .map(|ap| ap.value_type)
-                        .collect::<Vec<Type>>();
+                    let return_types = &builder.func.signature.return_types();
                     bitcast_arguments(&mut state.stack, &return_types, builder);
                     builder.ins().return_(&state.stack)
                 }

--- a/cranelift-wasm/src/state/func_state.rs
+++ b/cranelift-wasm/src/state/func_state.rs
@@ -306,29 +306,38 @@ impl FuncTranslationState {
         (v1, v2, v3)
     }
 
+    /// Helper to ensure the the stack size is at least as big as `n`; note that due to
+    /// `debug_assert` this will not execute in non-optimized builds.
+    #[inline]
+    fn ensure_length_is_at_least(&self, n: usize) {
+        debug_assert!(
+            n <= self.stack.len(),
+            "attempted to access {} values but stack only has {} values",
+            n,
+            self.stack.len()
+        )
+    }
+
     /// Pop the top `n` values on the stack.
     ///
     /// The popped values are not returned. Use `peekn` to look at them before popping.
     pub(crate) fn popn(&mut self, n: usize) {
-        debug_assert!(
-            n <= self.stack.len(),
-            "popn({}) but stack only has {} values",
-            n,
-            self.stack.len()
-        );
+        self.ensure_length_is_at_least(n);
         let new_len = self.stack.len() - n;
         self.stack.truncate(new_len);
     }
 
     /// Peek at the top `n` values on the stack in the order they were pushed.
     pub(crate) fn peekn(&self, n: usize) -> &[Value] {
-        debug_assert!(
-            n <= self.stack.len(),
-            "peekn({}) but stack only has {} values",
-            n,
-            self.stack.len()
-        );
+        self.ensure_length_is_at_least(n);
         &self.stack[self.stack.len() - n..]
+    }
+
+    /// Peek at the top `n` values on the stack in the order they were pushed.
+    pub(crate) fn peekn_mut(&mut self, n: usize) -> &mut [Value] {
+        self.ensure_length_is_at_least(n);
+        let len = self.stack.len();
+        &mut self.stack[len - n..]
     }
 
     /// Push a block on the control stack.

--- a/cranelift-wasm/src/state/func_state.rs
+++ b/cranelift-wasm/src/state/func_state.rs
@@ -474,7 +474,7 @@ impl FuncTranslationState {
             Occupied(entry) => Ok(*entry.get()),
             Vacant(entry) => {
                 let sig = environ.make_indirect_sig(func, index)?;
-                Ok(*entry.insert((sig, normal_args(&func.dfg.signatures[sig]))))
+                Ok(*entry.insert((sig, func.dfg.signatures[sig].num_normal_params())))
             }
         }
     }
@@ -495,17 +495,8 @@ impl FuncTranslationState {
             Vacant(entry) => {
                 let fref = environ.make_direct_func(func, index)?;
                 let sig = func.dfg.ext_funcs[fref].signature;
-                Ok(*entry.insert((fref, normal_args(&func.dfg.signatures[sig]))))
+                Ok(*entry.insert((fref, func.dfg.signatures[sig].num_normal_params())))
             }
         }
     }
-}
-
-/// Count the number of normal parameters in a signature.
-/// Exclude special-purpose parameters that represent runtime stuff and not WebAssembly arguments.
-fn normal_args(sig: &ir::Signature) -> usize {
-    sig.params
-        .iter()
-        .filter(|arg| arg.purpose == ir::ArgumentPurpose::Normal)
-        .count()
 }

--- a/wasmtests/call-simd.wat
+++ b/wasmtests/call-simd.wat
@@ -1,0 +1,14 @@
+(module
+  (func $main
+    (v128.const i32x4 1 2 3 4)
+    (v128.const i32x4 1 2 3 4)
+    (call $add)
+    drop
+  )
+  (func $add (param $a v128) (param $b v128) (result v128)
+    (local.get $a)
+    (local.get $b)
+    (i32x4.add)
+  )
+  (start $main)
+)

--- a/wasmtests/icall-simd.wat
+++ b/wasmtests/icall-simd.wat
@@ -1,0 +1,7 @@
+(module
+  (type $ft (func (param v128) (result v128)))
+  (func $foo (export "foo") (param i32) (param v128) (result v128)
+    (call_indirect (type $ft) (local.get 1) (local.get 0))
+  )
+  (table (;0;) 23 23 anyfunc)
+)


### PR DESCRIPTION
- [x] This has been discussed in issue #1192.
- [x] A short description of what this does, why it is needed: I have other PRs (#1236 and #1251) to solve the underlying SIMD type issues in different ways; however, they still fall short because I have not yet found a good way to retain the necessary type information to inform cranelift that, e.g., `iadd` needs to operate on `i32x4` and not the default `i8x16`. This PR adds more `raw_bitcasts` so that function signatures returning vectors will have some bitcasts before `return` to convert the actual vector type (e.g. `i32x4`) into the expected signature type (e.g. the default `i8x16`). I propose we merge something like this first so I can get more SIMD spec tests running and circle back to a better solution to #1192 afterwards.
- [ ] This PR contains test cases, if meaningful.
- [x] A reviewer from the core maintainer team has been assigned for this PR.