### PR TITLE
Bitcast values incoming to `vall_true` and `vany_true` before use in Wasm translation

### DIFF
--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -1226,14 +1226,16 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         | Operator::I16x8AnyTrue
         | Operator::I32x4AnyTrue
         | Operator::I64x2AnyTrue => {
-            let bool_result = builder.ins().vany_true(state.pop1());
+            let a = pop1_with_bitcast(state, type_of(op), builder);
+            let bool_result = builder.ins().vany_true(a);
             state.push1(builder.ins().bint(I32, bool_result))
         }
         Operator::I8x16AllTrue
         | Operator::I16x8AllTrue
         | Operator::I32x4AllTrue
         | Operator::I64x2AllTrue => {
-            let bool_result = builder.ins().vall_true(state.pop1());
+            let a = pop1_with_bitcast(state, type_of(op), builder);
+            let bool_result = builder.ins().vall_true(a);
             state.push1(builder.ins().bint(I32, bool_result))
         }
         Operator::I8x16Eq | Operator::I16x8Eq | Operator::I32x4Eq => {


### PR DESCRIPTION
- [x] This has not been discussed in an issue; the change is small.
- [x] A short description of what this does, why it is needed: while running SIMD spec tests in `wasmtime`, I discovered that not bitcasting the default vector type, `I8X16`, to the expected type caused Wasm's `all_true` and `any_true` to return incorrect results. See, for example, https://github.com/WebAssembly/testsuite/blob/78d896f08895cbc2c8cb9da1fe64df56c5aeb6aa/proposals/simd/simd_boolean.wast#L77-L78: the reason this test fails is that Cranelift should translate `i16x8.all_true` to `vall_true.i16x8` but without the bitcast it is translated to `vall_true.i8x16`, leaving zeroes in alternating 8-bit wide lanes.
- [x] This PR contains test cases, if meaningful: the test cases exist but unfortunately in a different repository.
- [x] A reviewer from the core maintainer team has been assigned for this PR.