### PR TITLE
fix some clippy warnings

### DIFF
--- a/cranelift-codegen/build.rs
+++ b/cranelift-codegen/build.rs
@@ -61,7 +61,7 @@ fn main() {
         process::exit(1);
     }
 
-    if let Ok(_) = env::var("CRANELIFT_VERBOSE") {
+    if env::var("CRANELIFT_VERBOSE").is_ok() {
         for isa in &isas {
             println!("cargo:warning=Includes support for {} ISA", isa.to_string());
         }

--- a/cranelift-codegen/meta/src/cdsl/type_inference.rs
+++ b/cranelift-codegen/meta/src/cdsl/type_inference.rs
@@ -459,7 +459,7 @@ fn constrain_fixpoint(tv1: &TypeVar, tv2: &TypeVar) {
         }
     }
 
-    let old_tv2_ts = tv2.get_typeset().clone();
+    let old_tv2_ts = tv2.get_typeset();
     tv1.constrain_types(tv2.clone());
     // The above loop should ensure that all reference cycles have been handled.
     assert!(old_tv2_ts == tv2.get_typeset());
@@ -627,7 +627,7 @@ pub(crate) fn infer_transform(
         .map(|&var_index| {
             let var = var_pool.get_mut(var_index);
             let tv = type_env.get_equivalent(&var.get_or_create_typevar());
-            (var_index, tv.get_typeset().clone())
+            (var_index, tv.get_typeset())
         })
         .collect::<Vec<_>>();
 

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -1381,7 +1381,7 @@ pub(crate) fn define<'shared>(
         recipes.add_template_recipe(
             EncodingRecipeBuilder::new("fst", &formats.store, 1)
                 .operands_in(vec![fpr, gpr])
-                .inst_predicate(has_no_offset.clone())
+                .inst_predicate(has_no_offset)
                 .clobbers_flags(false)
                 .compute_size("size_plus_maybe_sib_or_offset_for_in_reg_1")
                 .emit(
@@ -1465,7 +1465,7 @@ pub(crate) fn define<'shared>(
         recipes.add_template_recipe(
             EncodingRecipeBuilder::new("fstDisp8", &formats.store, 2)
                 .operands_in(vec![fpr, gpr])
-                .inst_predicate(has_small_offset.clone())
+                .inst_predicate(has_small_offset)
                 .clobbers_flags(false)
                 .compute_size("size_plus_maybe_sib_for_in_reg_1")
                 .emit(
@@ -1628,7 +1628,7 @@ pub(crate) fn define<'shared>(
         recipes.add_template_recipe(
             EncodingRecipeBuilder::new("fstWithIndex", &formats.store_complex, 2)
                 .operands_in(vec![fpr, gpr, gpr])
-                .inst_predicate(has_no_offset.clone())
+                .inst_predicate(has_no_offset)
                 .clobbers_flags(false)
                 .compute_size("size_plus_maybe_offset_for_in_reg_1")
                 .emit(
@@ -1698,7 +1698,7 @@ pub(crate) fn define<'shared>(
         recipes.add_template_recipe(
             EncodingRecipeBuilder::new("fstWithIndexDisp8", &formats.store_complex, 3)
                 .operands_in(vec![fpr, gpr, gpr])
-                .inst_predicate(has_small_offset.clone())
+                .inst_predicate(has_small_offset)
                 .clobbers_flags(false)
                 .emit(
                     r#"
@@ -1762,7 +1762,7 @@ pub(crate) fn define<'shared>(
         recipes.add_template_recipe(
             EncodingRecipeBuilder::new("fstWithIndexDisp32", &formats.store_complex, 6)
                 .operands_in(vec![fpr, gpr, gpr])
-                .inst_predicate(has_big_offset.clone())
+                .inst_predicate(has_big_offset)
                 .clobbers_flags(false)
                 .emit(
                     r#"
@@ -1892,7 +1892,7 @@ pub(crate) fn define<'shared>(
             EncodingRecipeBuilder::new("fld", &formats.load, 1)
                 .operands_in(vec![gpr])
                 .operands_out(vec![fpr])
-                .inst_predicate(has_no_offset.clone())
+                .inst_predicate(has_no_offset)
                 .clobbers_flags(false)
                 .compute_size("size_plus_maybe_sib_or_offset_for_in_reg_0")
                 .emit(
@@ -1948,7 +1948,7 @@ pub(crate) fn define<'shared>(
             EncodingRecipeBuilder::new("fldDisp8", &formats.load, 2)
                 .operands_in(vec![gpr])
                 .operands_out(vec![fpr])
-                .inst_predicate(has_small_offset.clone())
+                .inst_predicate(has_small_offset)
                 .clobbers_flags(false)
                 .compute_size("size_plus_maybe_sib_for_in_reg_0")
                 .emit(
@@ -2003,7 +2003,7 @@ pub(crate) fn define<'shared>(
             EncodingRecipeBuilder::new("fldDisp32", &formats.load, 5)
                 .operands_in(vec![gpr])
                 .operands_out(vec![fpr])
-                .inst_predicate(has_big_offset.clone())
+                .inst_predicate(has_big_offset)
                 .clobbers_flags(false)
                 .compute_size("size_plus_maybe_sib_for_in_reg_0")
                 .emit(
@@ -2064,7 +2064,7 @@ pub(crate) fn define<'shared>(
             EncodingRecipeBuilder::new("fldWithIndex", &formats.load_complex, 2)
                 .operands_in(vec![gpr, gpr])
                 .operands_out(vec![fpr])
-                .inst_predicate(has_no_offset.clone())
+                .inst_predicate(has_no_offset)
                 .clobbers_flags(false)
                 .compute_size("size_plus_maybe_offset_for_in_reg_0")
                 .emit(
@@ -2115,7 +2115,7 @@ pub(crate) fn define<'shared>(
             EncodingRecipeBuilder::new("fldWithIndexDisp8", &formats.load_complex, 3)
                 .operands_in(vec![gpr, gpr])
                 .operands_out(vec![fpr])
-                .inst_predicate(has_small_offset.clone())
+                .inst_predicate(has_small_offset)
                 .clobbers_flags(false)
                 .emit(
                     r#"
@@ -2160,7 +2160,7 @@ pub(crate) fn define<'shared>(
             EncodingRecipeBuilder::new("fldWithIndexDisp32", &formats.load_complex, 6)
                 .operands_in(vec![gpr, gpr])
                 .operands_out(vec![fpr])
-                .inst_predicate(has_big_offset.clone())
+                .inst_predicate(has_big_offset)
                 .clobbers_flags(false)
                 .emit(
                     r#"

--- a/cranelift-codegen/src/binemit/memorysink.rs
+++ b/cranelift-codegen/src/binemit/memorysink.rs
@@ -46,6 +46,8 @@ pub struct MemoryCodeSink<'a> {
 impl<'a> MemoryCodeSink<'a> {
     /// Create a new memory code sink that writes a function to the memory pointed to by `data`.
     ///
+    /// # Safety
+    ///
     /// This function is unsafe since `MemoryCodeSink` does not perform bounds checking on the
     /// memory buffer, and it can't guarantee that the `data` pointer is valid.
     pub unsafe fn new(

--- a/cranelift-codegen/src/context.rs
+++ b/cranelift-codegen/src/context.rs
@@ -175,6 +175,8 @@ impl Context {
     ///
     /// The machine code is not relocated. Instead, any relocations are emitted into `relocs`.
     ///
+    /// # Safety
+    ///
     /// This function is unsafe since it does not perform bounds checking on the memory buffer,
     /// and it can't guarantee that the `mem` pointer is valid.
     ///

--- a/cranelift-codegen/src/isa/mod.rs
+++ b/cranelift-codegen/src/isa/mod.rs
@@ -22,7 +22,6 @@
 //! ```
 //! # extern crate cranelift_codegen;
 //! # #[macro_use] extern crate target_lexicon;
-//! # fn main() {
 //! use cranelift_codegen::isa;
 //! use cranelift_codegen::settings::{self, Configurable};
 //! use std::str::FromStr;
@@ -40,7 +39,6 @@
 //!         let isa = isa_builder.finish(shared_flags);
 //!     }
 //! }
-//! # }
 //! ```
 //!
 //! The configured target ISA trait object is a `Box<TargetIsa>` which can be used for multiple

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -938,7 +938,7 @@ fn insert_common_epilogue(
             .entry(fp_pop_inst)
             .and_modify(|insts| {
                 *insts = insts
-                    .into_iter()
+                    .iter()
                     .cloned()
                     .chain(std::iter::once(new_cfa))
                     .collect::<Box<[_]>>();

--- a/cranelift-codegen/src/licm.rs
+++ b/cranelift-codegen/src/licm.rs
@@ -73,7 +73,6 @@ fn create_pre_header(
     let pool = &mut ListPool::<Value>::new();
     let header_args_values = func.dfg.ebb_params(header).to_vec();
     let header_args_types: Vec<Type> = header_args_values
-        .clone()
         .into_iter()
         .map(|val| func.dfg.value_type(val))
         .collect();

--- a/cranelift-codegen/src/verifier/mod.rs
+++ b/cranelift-codegen/src/verifier/mod.rs
@@ -107,7 +107,7 @@ pub struct VerifierError {
 fn format_context(context: &Option<String>) -> String {
     match context {
         None => "".to_string(),
-        Some(c) => format!(" ({})", c).to_string(),
+        Some(c) => format!(" ({})", c),
     }
 }
 

--- a/cranelift-entity/src/boxed_slice.rs
+++ b/cranelift-entity/src/boxed_slice.rs
@@ -27,6 +27,10 @@ where
 {
     /// Create a new slice from a raw pointer. A safer way to create slices is
     /// to use `PrimaryMap::into_boxed_slice()`.
+    ///
+    /// # Safety
+    ///
+    /// This relies on `raw` pointing to a valid slice of `V`s.
     pub unsafe fn from_raw(raw: *mut [V]) -> Self {
         Self {
             elems: Box::from_raw(raw),


### PR DESCRIPTION
This PR removes a few needless clones and adds `# Safety` sections to docs of unsafe functions.