### PR TITLE
Fix legalization of SIMD `fneg`

### DIFF
--- a/filetests/isa/x86/simd-arithmetic-legalize.clif
+++ b/filetests/isa/x86/simd-arithmetic-legalize.clif
@@ -39,13 +39,17 @@ function %fneg_legalized() {
 ebb0:
     v0 = vconst.f32x4 [0x1.0 0x2.0 0x3.0 0x4.0]
     v1 = fneg v0
-    ; check: v4 = vconst.f32x4 0x00
-    ; nextln: v1 = fsub v4, v0
+    ; check: v4 = vconst.i32x4 0xffffffffffffffffffffffffffffffff
+    ; nextln: v5 = ishl_imm v4, 31
+    ; nextln: v6 = raw_bitcast.f32x4 v5
+    ; nextln: v1 = bxor v0, v6
 
     v2 = vconst.f64x2 [0x1.0 0x2.0]
     v3 = fneg v2
-    ; check: v5 = vconst.f64x2 0x00
-    ; nextln: v3 = fsub v5, v2
+    ; check: v7 = vconst.i64x2 0xffffffffffffffffffffffffffffffff
+    ; nextln: v8 = ishl_imm v7, 63
+    ; nextln: v9 = raw_bitcast.f64x2 v8
+    ; nextln: v3 = bxor v2, v9
 
     return
 }

--- a/filetests/isa/x86/simd-arithmetic-run.clif
+++ b/filetests/isa/x86/simd-arithmetic-run.clif
@@ -240,6 +240,19 @@ ebb0:
 }
 ; run
 
+function %fneg_f32x4() -> b1 {
+ebb0:
+    v0 = vconst.f32x4 [0x0.0 -0x0.0 -Inf Inf]
+    v1 = fneg v0
+
+    v2 = vconst.f32x4 [-0x0.0 0x0.0 Inf -Inf]
+    v3 = fcmp eq v1, v2
+    v4 = vall_true v3
+
+    return v4
+}
+; run
+
 function %fabs_f32x4() -> b1 {
 ebb0:
     v0 = vconst.f32x4 [0x0.0 -0x1.0 0x2.0 -0x3.0]


### PR DESCRIPTION
Previously `fsub` was used but this fails when negating -0.0 and +0.0 in the SIMD spec tests; using more instructions, this change uses shifts to create a constant for flipping the most significant bit of each lane with `bxor`.