### PR TITLE
Fix `scalar_to_vector`: move not wide enough for 64-bit values

### DIFF
--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -1746,10 +1746,13 @@ pub(crate) fn define(
         } else {
             let template = rec_frurm.opcodes(&MOVD_LOAD_XMM);
             if ty.lane_bits() < 64 {
-                // no 32-bit encodings for 64-bit widths
                 e.enc32(instruction.clone(), template.clone());
+                e.enc_x86_64(instruction, template);
+            } else {
+                // No 32-bit encodings for 64-bit widths.
+                assert_eq!(ty.lane_bits(), 64);
+                e.enc64(instruction, template.rex().w());
             }
-            e.enc_x86_64(instruction, template);
         }
     }
 

--- a/filetests/isa/x86/scalar_to_vector-binemit.clif
+++ b/filetests/isa/x86/scalar_to_vector-binemit.clif
@@ -27,6 +27,6 @@ ebb0:
 function %test_scalar_to_vector_i64() {
 ebb0:
 [-, %rdx]   v0 = iconst.i64 42
-[-, %xmm7]  v1 = scalar_to_vector.i64x2 v0    ; bin: 66 0f 6e fa
+[-, %xmm7]  v1 = scalar_to_vector.i64x2 v0    ; bin: 66 48 0f 6e fa
             return
 }

--- a/filetests/isa/x86/simd-construction-run.clif
+++ b/filetests/isa/x86/simd-construction-run.clif
@@ -1,0 +1,14 @@
+test run
+set enable_simd
+target x86_64 skylake
+
+function %splat_i64x2() -> b1 {
+ebb0:
+    v0 = iconst.i64 -1
+    v1 = splat.i64x2 v0
+    v2 = vconst.i64x2 [-1 -1]
+    v3 = icmp eq v1, v2
+    v8 = vall_true v3
+    return v8
+}
+; run


### PR DESCRIPTION
Previously, the use of `enc_x86_64` emitted two encodings for `scalar_to_vector.i64`: a 32-bit move to an XMM register and a 64-bit move to an XMM register. Due to the ordering in `enc_x86_64`, the 32-bit move was used when legalizing `splat`, resulting in missing 4 bytes when splatting 64-bit values. This change makes 64-bit values always use the REX.W encoding, leaving lower-width values with three encodings: 32-bit, 64-bit no REX, and 64-bit with REX.W.