### PR TITLE
[module] Finalize definitions for the end-user

### DIFF
--- a/cranelift-module/src/module.rs
+++ b/cranelift-module/src/module.rs
@@ -714,7 +714,8 @@ where
     /// Consume the module and return the resulting `Product`. Some `Backend`
     /// implementations may provide additional functionality available after
     /// a `Module` is complete.
-    pub fn finish(self) -> B::Product {
+    pub fn finish(mut self) -> B::Product {
+        self.finalize_definitions();
         self.backend.finish()
     }
 }


### PR DESCRIPTION
- [x] This has been discussed in issue #1288 
- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.

This removes the need for end-users of `cranelift-module` to call `module.finalize_definitions` before `module.finish` is called. It is fine for `finalize_definitions` to remain `pub` because the implementation calls `.drain()` on all relevant data, so it will never be finalized twice.

- [ ] This PR contains test cases, if meaningful.

N/A, no new features.

- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.

I am not sure who should review this. r? @bnjbvr 
