### PR TITLE
Make `get_libcall_funcref` `pub(crate)`

### DIFF
--- a/cranelift-codegen/src/ir/libcall.rs
+++ b/cranelift-codegen/src/ir/libcall.rs
@@ -106,7 +106,7 @@ impl LibCall {
 /// for `inst`.
 ///
 /// If there is an existing reference, use it, otherwise make a new one.
-pub fn get_libcall_funcref(
+pub(crate) fn get_libcall_funcref(
     libcall: LibCall,
     call_conv: CallConv,
     func: &mut Function,

--- a/cranelift-codegen/src/ir/mod.rs
+++ b/cranelift-codegen/src/ir/mod.rs
@@ -14,7 +14,7 @@ pub mod immediates;
 pub mod instructions;
 pub mod jumptable;
 pub mod layout;
-mod libcall;
+pub(crate) mod libcall;
 mod memflags;
 mod progpoint;
 mod sourceloc;
@@ -49,7 +49,6 @@ pub use crate::ir::instructions::{
 };
 pub use crate::ir::jumptable::JumpTableData;
 pub use crate::ir::layout::Layout;
-pub(crate) use crate::ir::libcall::get_libcall_funcref;
 pub use crate::ir::libcall::{get_probestack_funcref, LibCall};
 pub use crate::ir::memflags::MemFlags;
 pub use crate::ir::progpoint::{ExpandedProgramPoint, ProgramOrder, ProgramPoint};

--- a/cranelift-codegen/src/ir/mod.rs
+++ b/cranelift-codegen/src/ir/mod.rs
@@ -49,7 +49,8 @@ pub use crate::ir::instructions::{
 };
 pub use crate::ir::jumptable::JumpTableData;
 pub use crate::ir::layout::Layout;
-pub use crate::ir::libcall::{get_libcall_funcref, get_probestack_funcref, LibCall};
+pub(crate) use crate::ir::libcall::get_libcall_funcref;
+pub use crate::ir::libcall::{get_probestack_funcref, LibCall};
 pub use crate::ir::memflags::MemFlags;
 pub use crate::ir::progpoint::{ExpandedProgramPoint, ProgramOrder, ProgramPoint};
 pub use crate::ir::sourceloc::SourceLoc;

--- a/cranelift-codegen/src/legalizer/libcall.rs
+++ b/cranelift-codegen/src/legalizer/libcall.rs
@@ -1,7 +1,7 @@
 //! Expanding instructions as runtime library calls.
 
 use crate::ir;
-use crate::ir::{get_libcall_funcref, InstBuilder};
+use crate::ir::{libcall::get_libcall_funcref, InstBuilder};
 use crate::isa::{CallConv, TargetIsa};
 use crate::legalizer::boundary::legalize_libcall_signature;
 use alloc::vec::Vec;


### PR DESCRIPTION
- [x] This has been discussed in issue #1273
- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.

Since `get_libcall_funcref` is only used internally by the verifier,
it doesn't make sense to have it be public. This will encourage users to
look elsewhere for `memcpy` (they should be looking at
https://docs.rs/cranelift-frontend/0.51.0/cranelift_frontend/struct.FunctionBuilder.html#method.emit_small_memcpy)

- [ ] This PR contains test cases, if meaningful.

N/A

- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.

I am not sure who should review this PR. r? @bnjbvr 