### PR TITLE
Fix build failure in cranelift-codegen

### DIFF
--- a/cranelift-codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift-codegen/meta/src/isa/x86/legalize.rs
@@ -561,7 +561,7 @@ pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &Instruct
         narrow.legalize(
             def!(b = fneg(a)),
             vec![
-                def!(c = vconst(ones)),
+                def!(c = vconst(u128_ones)),
                 def!(d = ishl_imm(c, uimm8_shift)), // Create a mask of all 0s except the MSB.
                 def!(e = bitcast_to_float(d)),      // Cast mask to the floating-point type.
                 def!(b = bxor(a, e)),               // Flip the MSB.


### PR DESCRIPTION
#1278 renamed `ones` to `u128_ones`, but #1286 added a new usage of `ones`.
```
error[E0425]: cannot find value `ones` in this scope
   --> cranelift-codegen/meta/src/isa/x86/legalize.rs:564:33
    |
564 |                 def!(c = vconst(ones)),
    |                                 ^^^^ not found in this scope
```
r? @abrown 