### PR TITLE
Add a DynRex recipe type for x86, decreasing the number of recipes

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/recipes.rs
+++ b/cranelift-codegen/meta/src/cdsl/recipes.rs
@@ -172,7 +172,7 @@ pub(crate) struct EncodingRecipeBuilder {
     pub base_size: u64,
     pub operands_in: Option<Vec<OperandConstraint>>,
     pub operands_out: Option<Vec<OperandConstraint>>,
-    compute_size: Option<&'static str>,
+    pub compute_size: Option<&'static str>,
     pub branch_range: Option<BranchRange>,
     pub emit: Option<String>,
     clobbers_flags: Option<bool>,

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -61,7 +61,7 @@ impl<'builder> RecipeGroup<'builder> {
         self.templates
             .iter()
             .find(|recipe| recipe.name() == name)
-            .unwrap_or_else(|| panic!("unknown tail recipe name: {}. Try recipe?", name))
+            .unwrap_or_else(|| panic!("unknown template name: {}. Try recipe?", name))
     }
 }
 
@@ -248,7 +248,7 @@ impl<'builder> Template<'builder> {
     pub fn nonrex(&self) -> Self {
         assert!(
             self.rex_kind != RexRecipeKind::AlwaysEmitRex,
-            "Tail recipe requires REX prefix."
+            "Template requires REX prefix."
         );
         let mut copy = self.clone();
         copy.rex_kind = RexRecipeKind::NeverEmitRex;
@@ -257,7 +257,7 @@ impl<'builder> Template<'builder> {
     pub fn rex(&self) -> Self {
         assert!(
             self.rex_kind != RexRecipeKind::NeverEmitRex,
-            "Tail recipe requires no REX prefix."
+            "Template requires no REX prefix."
         );
         if let Some(prefixed) = &self.when_prefixed {
             let mut ret = prefixed.rex();
@@ -272,10 +272,9 @@ impl<'builder> Template<'builder> {
         copy
     }
     pub fn infer_rex(&self) -> Self {
-        // TODO: when_prefixed is a hack that hurts clarity; get rid of it.
         assert!(
             self.rex_kind != RexRecipeKind::NeverEmitRex,
-            "Tail recipe requires no REX prefix."
+            "Template requires no REX prefix."
         );
         assert!(
             self.when_prefixed.is_none(),
@@ -519,7 +518,7 @@ pub(crate) fn define<'shared>(
                 ),
             regs,
         )
-        .inferred_rex_compute_size("size_with_inferred_rex_for_two_in_regs"),
+        .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0_inreg1"),
     );
 
     // XX /r with operands swapped. (RM form).
@@ -536,7 +535,7 @@ pub(crate) fn define<'shared>(
                 ),
             regs,
         )
-        .inferred_rex_compute_size("size_with_inferred_rex_for_two_in_regs"),
+        .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0_inreg1"),
     );
 
     // XX /r with FPR ins and outs. A form.
@@ -602,7 +601,7 @@ pub(crate) fn define<'shared>(
                 ),
             regs,
         )
-        .inferred_rex_compute_size("size_with_inferred_rex_for_one_in_reg"),
+        .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0"),
     );
 
     // XX /r, but for a unary operator with separate input/output register, like
@@ -621,7 +620,7 @@ pub(crate) fn define<'shared>(
                 ),
             regs,
         )
-        .inferred_rex_compute_size("size_with_inferred_rex_for_1in_1out"),
+        .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0_outreg0"),
     );
 
     // Same as umr, but with FPR -> GPR registers.
@@ -741,7 +740,7 @@ pub(crate) fn define<'shared>(
                 ),
             regs,
         )
-        .inferred_rex_compute_size("size_with_inferred_rex_for_1in_1out"),
+        .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0_outreg0"),
     );
 
     // XX /r, RM form, FPR -> GPR.
@@ -889,7 +888,7 @@ pub(crate) fn define<'shared>(
                     ),
                 regs,
             )
-            .inferred_rex_compute_size("size_with_inferred_rex_for_one_in_reg"),
+            .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0"),
         );
 
         recipes.add_template_recipe(
@@ -934,7 +933,7 @@ pub(crate) fn define<'shared>(
                     ),
                 regs,
             )
-            .inferred_rex_compute_size("size_with_inferred_rex_for_one_in_reg"),
+            .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0"),
         );
     }
 
@@ -1430,7 +1429,7 @@ pub(crate) fn define<'shared>(
                 .operands_in(vec![gpr, gpr])
                 .inst_predicate(has_no_offset.clone())
                 .clobbers_flags(false)
-                .compute_size("size_plus_maybe_sib_or_offset_for_in_reg_1")
+                .compute_size("size_plus_maybe_sib_or_offset_for_inreg_1")
                 .emit(
                     r#"
                         if !flags.notrap() {
@@ -1458,7 +1457,7 @@ pub(crate) fn define<'shared>(
                     .operands_in(vec![abcd, gpr])
                     .inst_predicate(has_no_offset.clone())
                     .clobbers_flags(false)
-                    .compute_size("size_plus_maybe_sib_or_offset_for_in_reg_1")
+                    .compute_size("size_plus_maybe_sib_or_offset_for_inreg_1")
                     .emit(
                         r#"
                         if !flags.notrap() {
@@ -1487,7 +1486,7 @@ pub(crate) fn define<'shared>(
                 .operands_in(vec![fpr, gpr])
                 .inst_predicate(has_no_offset)
                 .clobbers_flags(false)
-                .compute_size("size_plus_maybe_sib_or_offset_for_in_reg_1")
+                .compute_size("size_plus_maybe_sib_or_offset_for_inreg_1")
                 .emit(
                     r#"
                         if !flags.notrap() {
@@ -1516,7 +1515,7 @@ pub(crate) fn define<'shared>(
                 .operands_in(vec![gpr, gpr])
                 .inst_predicate(has_small_offset.clone())
                 .clobbers_flags(false)
-                .compute_size("size_plus_maybe_sib_for_in_reg_1")
+                .compute_size("size_plus_maybe_sib_for_inreg_1")
                 .emit(
                     r#"
                         if !flags.notrap() {
@@ -1543,7 +1542,7 @@ pub(crate) fn define<'shared>(
                     .operands_in(vec![abcd, gpr])
                     .inst_predicate(has_small_offset.clone())
                     .clobbers_flags(false)
-                    .compute_size("size_plus_maybe_sib_for_in_reg_1")
+                    .compute_size("size_plus_maybe_sib_for_inreg_1")
                     .emit(
                         r#"
                         if !flags.notrap() {
@@ -1571,7 +1570,7 @@ pub(crate) fn define<'shared>(
                 .operands_in(vec![fpr, gpr])
                 .inst_predicate(has_small_offset)
                 .clobbers_flags(false)
-                .compute_size("size_plus_maybe_sib_for_in_reg_1")
+                .compute_size("size_plus_maybe_sib_for_inreg_1")
                 .emit(
                     r#"
                         if !flags.notrap() {
@@ -1595,7 +1594,7 @@ pub(crate) fn define<'shared>(
             EncodingRecipeBuilder::new("stDisp32", &formats.store, 5)
                 .operands_in(vec![gpr, gpr])
                 .clobbers_flags(false)
-                .compute_size("size_plus_maybe_sib_for_in_reg_1")
+                .compute_size("size_plus_maybe_sib_for_inreg_1")
                 .emit(
                     r#"
                         if !flags.notrap() {
@@ -1621,7 +1620,7 @@ pub(crate) fn define<'shared>(
                 EncodingRecipeBuilder::new("stDisp32_abcd", &formats.store, 5)
                     .operands_in(vec![abcd, gpr])
                     .clobbers_flags(false)
-                    .compute_size("size_plus_maybe_sib_for_in_reg_1")
+                    .compute_size("size_plus_maybe_sib_for_inreg_1")
                     .emit(
                         r#"
                         if !flags.notrap() {
@@ -1648,7 +1647,7 @@ pub(crate) fn define<'shared>(
             EncodingRecipeBuilder::new("fstDisp32", &formats.store, 5)
                 .operands_in(vec![fpr, gpr])
                 .clobbers_flags(false)
-                .compute_size("size_plus_maybe_sib_for_in_reg_1")
+                .compute_size("size_plus_maybe_sib_for_inreg_1")
                 .emit(
                     r#"
                         if !flags.notrap() {
@@ -1681,7 +1680,7 @@ pub(crate) fn define<'shared>(
                 .operands_in(vec![gpr, gpr, gpr])
                 .inst_predicate(has_no_offset.clone())
                 .clobbers_flags(false)
-                .compute_size("size_plus_maybe_offset_for_in_reg_1")
+                .compute_size("size_plus_maybe_offset_for_inreg_1")
                 .emit(
                     r#"
                         if !flags.notrap() {
@@ -1708,7 +1707,7 @@ pub(crate) fn define<'shared>(
                 .operands_in(vec![abcd, gpr, gpr])
                 .inst_predicate(has_no_offset.clone())
                 .clobbers_flags(false)
-                .compute_size("size_plus_maybe_offset_for_in_reg_1")
+                .compute_size("size_plus_maybe_offset_for_inreg_1")
                 .emit(
                     r#"
                         if !flags.notrap() {
@@ -1734,7 +1733,7 @@ pub(crate) fn define<'shared>(
                 .operands_in(vec![fpr, gpr, gpr])
                 .inst_predicate(has_no_offset)
                 .clobbers_flags(false)
-                .compute_size("size_plus_maybe_offset_for_in_reg_1")
+                .compute_size("size_plus_maybe_offset_for_inreg_1")
                 .emit(
                     r#"
                         if !flags.notrap() {
@@ -1971,7 +1970,7 @@ pub(crate) fn define<'shared>(
                 .operands_out(vec![gpr])
                 .inst_predicate(has_no_offset.clone())
                 .clobbers_flags(false)
-                .compute_size("size_plus_maybe_sib_or_offset_for_in_reg_0")
+                .compute_size("size_plus_maybe_sib_or_offset_for_inreg_0")
                 .emit(
                     r#"
                         if !flags.notrap() {
@@ -1998,7 +1997,7 @@ pub(crate) fn define<'shared>(
                 .operands_out(vec![fpr])
                 .inst_predicate(has_no_offset)
                 .clobbers_flags(false)
-                .compute_size("size_plus_maybe_sib_or_offset_for_in_reg_0")
+                .compute_size("size_plus_maybe_sib_or_offset_for_inreg_0")
                 .emit(
                     r#"
                         if !flags.notrap() {
@@ -2028,7 +2027,7 @@ pub(crate) fn define<'shared>(
                 .operands_out(vec![gpr])
                 .inst_predicate(has_small_offset.clone())
                 .clobbers_flags(false)
-                .compute_size("size_plus_maybe_sib_for_in_reg_0")
+                .compute_size("size_plus_maybe_sib_for_inreg_0")
                 .emit(
                     r#"
                         if !flags.notrap() {
@@ -2054,7 +2053,7 @@ pub(crate) fn define<'shared>(
                 .operands_out(vec![fpr])
                 .inst_predicate(has_small_offset)
                 .clobbers_flags(false)
-                .compute_size("size_plus_maybe_sib_for_in_reg_0")
+                .compute_size("size_plus_maybe_sib_for_inreg_0")
                 .emit(
                     r#"
                         if !flags.notrap() {
@@ -2083,7 +2082,7 @@ pub(crate) fn define<'shared>(
                 .operands_out(vec![gpr])
                 .inst_predicate(has_big_offset.clone())
                 .clobbers_flags(false)
-                .compute_size("size_plus_maybe_sib_for_in_reg_0")
+                .compute_size("size_plus_maybe_sib_for_inreg_0")
                 .emit(
                     r#"
                         if !flags.notrap() {
@@ -2109,7 +2108,7 @@ pub(crate) fn define<'shared>(
                 .operands_out(vec![fpr])
                 .inst_predicate(has_big_offset)
                 .clobbers_flags(false)
-                .compute_size("size_plus_maybe_sib_for_in_reg_0")
+                .compute_size("size_plus_maybe_sib_for_inreg_0")
                 .emit(
                     r#"
                         if !flags.notrap() {
@@ -2143,7 +2142,7 @@ pub(crate) fn define<'shared>(
                 .operands_out(vec![gpr])
                 .inst_predicate(has_no_offset.clone())
                 .clobbers_flags(false)
-                .compute_size("size_plus_maybe_offset_for_in_reg_0")
+                .compute_size("size_plus_maybe_offset_for_inreg_0")
                 .emit(
                     r#"
                         if !flags.notrap() {
@@ -2170,7 +2169,7 @@ pub(crate) fn define<'shared>(
                 .operands_out(vec![fpr])
                 .inst_predicate(has_no_offset)
                 .clobbers_flags(false)
-                .compute_size("size_plus_maybe_offset_for_in_reg_0")
+                .compute_size("size_plus_maybe_offset_for_inreg_0")
                 .emit(
                     r#"
                         if !flags.notrap() {
@@ -2500,7 +2499,7 @@ pub(crate) fn define<'shared>(
             .operands_out(vec![gpr])
             .clobbers_flags(false)
             .inst_predicate(valid_scale(&*formats.branch_table_entry))
-            .compute_size("size_plus_maybe_offset_for_in_reg_1")
+            .compute_size("size_plus_maybe_offset_for_inreg_1")
             .emit(
                 r#"
                     {{PUT_OP}}(bits, rex3(in_reg1, out_reg0, in_reg0), sink);
@@ -2674,7 +2673,7 @@ pub(crate) fn define<'shared>(
                 ),
             regs,
         )
-        .inferred_rex_compute_size("size_with_inferred_rex_for_1in_1out"),
+        .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0_outreg0"),
     );
 
     // Arithematic with flag I/O.
@@ -2697,7 +2696,7 @@ pub(crate) fn define<'shared>(
                 ),
             regs,
         )
-        .inferred_rex_compute_size("size_with_inferred_rex_for_two_in_regs"),
+        .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0_inreg1"),
     );
 
     // XX /r, MR form. Add two GPR registers and get carry flag.
@@ -2719,7 +2718,7 @@ pub(crate) fn define<'shared>(
                 ),
             regs,
         )
-        .inferred_rex_compute_size("size_with_inferred_rex_for_two_in_regs"),
+        .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0_inreg1"),
     );
 
     // XX /r, MR form. Add two GPR registers with carry flag.
@@ -2744,7 +2743,7 @@ pub(crate) fn define<'shared>(
                 ),
             regs,
         )
-        .inferred_rex_compute_size("size_with_inferred_rex_for_two_in_regs"),
+        .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0_inreg1"),
     );
 
     // Compare and set flags.
@@ -2763,7 +2762,7 @@ pub(crate) fn define<'shared>(
                 ),
             regs,
         )
-        .inferred_rex_compute_size("size_with_inferred_rex_for_two_in_regs"),
+        .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0_inreg1"),
     );
 
     // Same as rcmp, but second operand is the stack pointer.
@@ -2813,7 +2812,7 @@ pub(crate) fn define<'shared>(
                     ),
                 regs,
             )
-            .inferred_rex_compute_size("size_with_inferred_rex_for_one_in_reg"),
+            .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0"),
         );
 
         let has_big_offset =
@@ -2836,7 +2835,7 @@ pub(crate) fn define<'shared>(
                     ),
                 regs,
             )
-            .inferred_rex_compute_size("size_with_inferred_rex_for_one_in_reg"),
+            .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0"),
         );
     }
 
@@ -2871,7 +2870,7 @@ pub(crate) fn define<'shared>(
                 ),
             regs,
         )
-        .inferred_rex_compute_size("size_with_inferred_rex_for_one_in_reg"),
+        .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0"),
     );
 
     recipes.add_template(
@@ -2892,7 +2891,7 @@ pub(crate) fn define<'shared>(
                 ),
             regs,
         )
-        .inferred_rex_compute_size("size_with_inferred_rex_for_one_in_reg"),
+        .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0"),
     );
 
     // 8-bit test-and-branch.
@@ -3041,7 +3040,7 @@ pub(crate) fn define<'shared>(
                 ),
             regs,
         )
-        .inferred_rex_compute_size("size_with_inferred_rex_for_two_in_regs"),
+        .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0_inreg1"),
     );
 
     recipes.add_template_recipe(
@@ -3083,7 +3082,7 @@ pub(crate) fn define<'shared>(
                     ),
                 regs,
             )
-            .inferred_rex_compute_size("size_with_inferred_rex_for_one_in_reg"),
+            .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0"),
         );
 
         let is_big_imm =
@@ -3111,7 +3110,7 @@ pub(crate) fn define<'shared>(
                     ),
                 regs,
             )
-            .inferred_rex_compute_size("size_with_inferred_rex_for_one_in_reg"),
+            .inferred_rex_compute_size("size_with_inferred_rex_for_inreg0"),
         );
     }
 

--- a/cranelift-codegen/shared/src/isa/x86/encoding_bits.rs
+++ b/cranelift-codegen/shared/src/isa/x86/encoding_bits.rs
@@ -57,6 +57,24 @@ impl EncodingBits {
         new
     }
 
+    /// Returns a copy of the EncodingBits with the RRR bits set.
+    #[inline]
+    pub fn with_rrr(self, rrr: u8) -> Self {
+        debug_assert_eq!(u8::from(self.rrr()), 0);
+        let mut enc = self.clone();
+        enc.write(RRR, rrr.into());
+        enc
+    }
+
+    /// Returns a copy of the EncodingBits with the REX.W bit set.
+    #[inline]
+    pub fn with_rex_w(self) -> Self {
+        debug_assert_eq!(self.rex_w(), 0);
+        let mut enc = self.clone();
+        enc.write(REX_W, 1);
+        enc
+    }
+
     /// Returns the raw bits.
     #[inline]
     pub fn bits(self) -> u16 {

--- a/cranelift-codegen/src/isa/x86/enc_tables.rs
+++ b/cranelift-codegen/src/isa/x86/enc_tables.rs
@@ -62,7 +62,7 @@ fn test_result(
     condition_func(out_reg)
 }
 
-fn size_plus_maybe_offset_for_in_reg_0(
+fn size_plus_maybe_offset_for_inreg_0(
     sizing: &RecipeSizing,
     _enc: Encoding,
     inst: Inst,
@@ -72,7 +72,7 @@ fn size_plus_maybe_offset_for_in_reg_0(
     let needs_offset = test_input(0, inst, divert, func, needs_offset);
     sizing.base_size + if needs_offset { 1 } else { 0 }
 }
-fn size_plus_maybe_offset_for_in_reg_1(
+fn size_plus_maybe_offset_for_inreg_1(
     sizing: &RecipeSizing,
     _enc: Encoding,
     inst: Inst,
@@ -82,7 +82,7 @@ fn size_plus_maybe_offset_for_in_reg_1(
     let needs_offset = test_input(1, inst, divert, func, needs_offset);
     sizing.base_size + if needs_offset { 1 } else { 0 }
 }
-fn size_plus_maybe_sib_for_in_reg_0(
+fn size_plus_maybe_sib_for_inreg_0(
     sizing: &RecipeSizing,
     _enc: Encoding,
     inst: Inst,
@@ -92,7 +92,7 @@ fn size_plus_maybe_sib_for_in_reg_0(
     let needs_sib = test_input(0, inst, divert, func, needs_sib_byte);
     sizing.base_size + if needs_sib { 1 } else { 0 }
 }
-fn size_plus_maybe_sib_for_in_reg_1(
+fn size_plus_maybe_sib_for_inreg_1(
     sizing: &RecipeSizing,
     _enc: Encoding,
     inst: Inst,
@@ -102,7 +102,7 @@ fn size_plus_maybe_sib_for_in_reg_1(
     let needs_sib = test_input(1, inst, divert, func, needs_sib_byte);
     sizing.base_size + if needs_sib { 1 } else { 0 }
 }
-fn size_plus_maybe_sib_or_offset_for_in_reg_0(
+fn size_plus_maybe_sib_or_offset_for_inreg_0(
     sizing: &RecipeSizing,
     _enc: Encoding,
     inst: Inst,
@@ -112,7 +112,7 @@ fn size_plus_maybe_sib_or_offset_for_in_reg_0(
     let needs_sib_or_offset = test_input(0, inst, divert, func, needs_sib_byte_or_offset);
     sizing.base_size + if needs_sib_or_offset { 1 } else { 0 }
 }
-fn size_plus_maybe_sib_or_offset_for_in_reg_1(
+fn size_plus_maybe_sib_or_offset_for_inreg_1(
     sizing: &RecipeSizing,
     _enc: Encoding,
     inst: Inst,
@@ -123,12 +123,12 @@ fn size_plus_maybe_sib_or_offset_for_in_reg_1(
     sizing.base_size + if needs_sib_or_offset { 1 } else { 0 }
 }
 
-/// Infers whether a dynamic REX prefix will be emitted, for use with one in-reg.
+/// Infers whether a dynamic REX prefix will be emitted, for use with one input reg.
 ///
 /// A REX prefix is known to be emitted if either:
 ///  1. The EncodingBits specify that REX.W is to be set.
 ///  2. Registers are used that require REX.R or REX.B bits for encoding.
-fn size_with_inferred_rex_for_one_in_reg(
+fn size_with_inferred_rex_for_inreg0(
     sizing: &RecipeSizing,
     enc: Encoding,
     inst: Inst,
@@ -137,24 +137,6 @@ fn size_with_inferred_rex_for_one_in_reg(
 ) -> u8 {
     let needs_rex = (EncodingBits::from(enc.bits()).rex_w() != 0)
         || test_input(0, inst, divert, func, is_extended_reg);
-    sizing.base_size + if needs_rex { 1 } else { 0 }
-}
-
-/// Infers whether a dynamic REX prefix will be emitted, for use with two in-regs.
-///
-/// A REX prefix is known to be emitted if either:
-///  1. The EncodingBits specify that REX.W is to be set.
-///  2. Registers are used that require REX.R or REX.B bits for encoding.
-fn size_with_inferred_rex_for_two_in_regs(
-    sizing: &RecipeSizing,
-    enc: Encoding,
-    inst: Inst,
-    divert: &RegDiversions,
-    func: &Function,
-) -> u8 {
-    let needs_rex = (EncodingBits::from(enc.bits()).rex_w() != 0)
-        || test_input(0, inst, divert, func, is_extended_reg)
-        || test_input(1, inst, divert, func, is_extended_reg);
     sizing.base_size + if needs_rex { 1 } else { 0 }
 }
 
@@ -184,9 +166,27 @@ fn size_with_inferred_rex_for_inreg2(
     sizing.base_size + if needs_rex { 1 } else { 0 }
 }
 
+/// Infers whether a dynamic REX prefix will be emitted, for use with two input registers.
+///
+/// A REX prefix is known to be emitted if either:
+///  1. The EncodingBits specify that REX.W is to be set.
+///  2. Registers are used that require REX.R or REX.B bits for encoding.
+fn size_with_inferred_rex_for_inreg0_inreg1(
+    sizing: &RecipeSizing,
+    enc: Encoding,
+    inst: Inst,
+    divert: &RegDiversions,
+    func: &Function,
+) -> u8 {
+    let needs_rex = (EncodingBits::from(enc.bits()).rex_w() != 0)
+        || test_input(0, inst, divert, func, is_extended_reg)
+        || test_input(1, inst, divert, func, is_extended_reg);
+    sizing.base_size + if needs_rex { 1 } else { 0 }
+}
+
 /// Infers whether a dynamic REX prefix will be emitted, based on a single
-/// in-reg and a single out-reg.
-fn size_with_inferred_rex_for_1in_1out(
+/// input register and a single output register.
+fn size_with_inferred_rex_for_inreg0_outreg0(
     sizing: &RecipeSizing,
     enc: Encoding,
     inst: Inst,

--- a/cranelift-codegen/src/isa/x86/enc_tables.rs
+++ b/cranelift-codegen/src/isa/x86/enc_tables.rs
@@ -16,8 +16,19 @@ use crate::isa::{self, TargetIsa};
 use crate::predicates;
 use crate::regalloc::RegDiversions;
 
+use cranelift_codegen_shared::isa::x86::EncodingBits;
+
 include!(concat!(env!("OUT_DIR"), "/encoding-x86.rs"));
 include!(concat!(env!("OUT_DIR"), "/legalize-x86.rs"));
+
+/// Whether the REX prefix is needed for encoding extended registers (via REX.R/B).
+///
+/// Normal x86 instructions have only 3 bits for encoding a register.
+/// The REX prefix adds REX.R and REX.B bits, interpreted as fourth bits.
+pub fn needs_rex_rb(reg: RegUnit) -> bool {
+    // Extended registers have the fourth bit set.
+    reg as u8 & 0b1000 != 0
+}
 
 pub fn needs_sib_byte(reg: RegUnit) -> bool {
     reg == RU::r12 as RegUnit || reg == RU::rsp as RegUnit
@@ -37,6 +48,21 @@ fn additional_size_if(
     condition_func: fn(RegUnit) -> bool,
 ) -> u8 {
     let addr_reg = divert.reg(func.dfg.inst_args(inst)[op_index], &func.locations);
+    if condition_func(addr_reg) {
+        1
+    } else {
+        0
+    }
+}
+
+fn additional_size_if_result(
+    result_index: usize,
+    inst: Inst,
+    divert: &RegDiversions,
+    func: &Function,
+    condition_func: fn(RegUnit) -> bool,
+) -> u8 {
+    let addr_reg = divert.reg(func.dfg.inst_results(inst)[result_index], &func.locations);
     if condition_func(addr_reg) {
         1
     } else {
@@ -97,6 +123,136 @@ fn size_plus_maybe_sib_or_offset_for_in_reg_1(
     func: &Function,
 ) -> u8 {
     sizing.base_size + additional_size_if(1, inst, divert, func, needs_sib_byte_or_offset)
+}
+
+/// Infers whether a dynamic REX prefix will be emitted, for use with one in-reg.
+///
+/// A REX prefix is known to be emitted if either:
+///  1. The EncodingBits specify that REX.W is to be set.
+///  2. Registers are used that require REX.R or REX.B bits for encoding.
+fn size_with_inferred_rex_for_one_in_reg(
+    sizing: &RecipeSizing,
+    enc: Encoding,
+    inst: Inst,
+    divert: &RegDiversions,
+    func: &Function,
+) -> u8 {
+    // Emit a REX prefix if REX.W is requested by the encoding.
+    let bits = EncodingBits::from(enc.bits());
+    if u8::from(bits.rex_w()) > 0 {
+        return sizing.base_size + 1;
+    }
+    sizing.base_size + additional_size_if(0, inst, divert, func, needs_rex_rb)
+}
+
+/// Infers whether a dynamic REX prefix will be emitted, for use with two in-regs.
+///
+/// A REX prefix is known to be emitted if either:
+///  1. The EncodingBits specify that REX.W is to be set.
+///  2. Registers are used that require REX.R or REX.B bits for encoding.
+fn size_with_inferred_rex_for_two_in_regs(
+    sizing: &RecipeSizing,
+    enc: Encoding,
+    inst: Inst,
+    divert: &RegDiversions,
+    func: &Function,
+) -> u8 {
+    // Emit a REX prefix if REX.W is requested by the encoding.
+    let bits = EncodingBits::from(enc.bits());
+    if u8::from(bits.rex_w()) > 0 {
+        return sizing.base_size + 1;
+    }
+
+    // Emit a REX prefix if REX.B is needed to encode the first register.
+    let reg0 = divert.reg(func.dfg.inst_args(inst)[0], &func.locations);
+    if needs_rex_rb(reg0) {
+        return sizing.base_size + 1;
+    }
+
+    // Emit a REX prefix if REX.R is needed to encode the second register.
+    sizing.base_size + additional_size_if(1, inst, divert, func, needs_rex_rb)
+}
+
+/// Infers whether a dynamic REX prefix will be emitted, based on the inreg1.
+fn size_with_inferred_rex_for_inreg1(
+    sizing: &RecipeSizing,
+    enc: Encoding,
+    inst: Inst,
+    divert: &RegDiversions,
+    func: &Function,
+) -> u8 {
+    // Emit a REX prefix if REX.W is requested by the encoding.
+    let bits = EncodingBits::from(enc.bits());
+    if u8::from(bits.rex_w()) > 0 {
+        return sizing.base_size + 1;
+    }
+    sizing.base_size + additional_size_if(1, inst, divert, func, needs_rex_rb)
+}
+
+/// Infers whether a dynamic REX prefix will be emitted, based on the inreg2.
+fn size_with_inferred_rex_for_inreg2(
+    sizing: &RecipeSizing,
+    enc: Encoding,
+    inst: Inst,
+    divert: &RegDiversions,
+    func: &Function,
+) -> u8 {
+    // Emit a REX prefix if REX.W is requested by the encoding.
+    let bits = EncodingBits::from(enc.bits());
+    if u8::from(bits.rex_w()) > 0 {
+        return sizing.base_size + 1;
+    }
+    sizing.base_size + additional_size_if(2, inst, divert, func, needs_rex_rb)
+}
+
+/// Infers whether a dynamic REX prefix will be emitted, based on a single
+/// in-reg and a single out-reg.
+fn size_with_inferred_rex_for_1in_1out(
+    sizing: &RecipeSizing,
+    enc: Encoding,
+    inst: Inst,
+    divert: &RegDiversions,
+    func: &Function,
+) -> u8 {
+    // Emit a REX prefix if REX.W is requested by the encoding.
+    let bits = EncodingBits::from(enc.bits());
+    if u8::from(bits.rex_w()) > 0 {
+        return sizing.base_size + 1;
+    }
+
+    // Emit a REX prefix if REX.B is needed to encode the in-register.
+    let reg0 = divert.reg(func.dfg.inst_args(inst)[0], &func.locations);
+    if needs_rex_rb(reg0) {
+        return sizing.base_size + 1;
+    }
+
+    sizing.base_size + additional_size_if_result(0, inst, divert, func, needs_rex_rb)
+}
+
+/// Infers whether a dynamic REX prefix will be emitted, for use with CMOV.
+///
+/// CMOV uses 3 inputs, with the REX is inferred from reg1 and reg2.
+fn size_with_inferred_rex_for_cmov(
+    sizing: &RecipeSizing,
+    enc: Encoding,
+    inst: Inst,
+    divert: &RegDiversions,
+    func: &Function,
+) -> u8 {
+    // Emit a REX prefix if REX.W is requested by the encoding.
+    let bits = EncodingBits::from(enc.bits());
+    if u8::from(bits.rex_w()) > 0 {
+        return sizing.base_size + 1;
+    }
+
+    // Emit a REX prefix if REX.B is needed to encode the first register.
+    let reg1 = divert.reg(func.dfg.inst_args(inst)[1], &func.locations);
+    if needs_rex_rb(reg1) {
+        return sizing.base_size + 1;
+    }
+
+    // Emit a REX prefix if REX.R is needed to encode the second register.
+    sizing.base_size + additional_size_if(2, inst, divert, func, needs_rex_rb)
 }
 
 /// If the value's definition is a constant immediate, returns its unpacked value, or None

--- a/filetests/isa/x86/legalize-br-icmp.clif
+++ b/filetests/isa/x86/legalize-br-icmp.clif
@@ -15,7 +15,7 @@ ebb1:
 ; sameln: function %br_icmp(i64 [%rdi]) fast {
 ; nextln:                                 ebb0(v0: i64):
 ; nextln: [RexOp1pu_id#b8]                    v1 = iconst.i64 0
-; nextln: [RexOp1icscc#8039]                  v2 = icmp eq v0, v1
+; nextln: [DynRexOp1icscc#8039]               v2 = icmp eq v0, v1
 ; nextln: [RexOp1t8jccb#75]                   brnz v2, ebb1
 ; nextln: [Op1jmpb#eb]                        jump ebb1
 ; nextln: 
@@ -37,7 +37,7 @@ ebb1(v2: i64):
 ; sameln: function %br_icmp_ebb_args(i64 [%rdi]) fast {
 ; nextln:                                 ebb0(v0: i64):
 ; nextln: [RexOp1pu_id#b8]                    v1 = iconst.i64 0
-; nextln: [RexOp1icscc#8039]                  v3 = icmp eq v0, v1
+; nextln: [DynRexOp1icscc#8039]               v3 = icmp eq v0, v1
 ; nextln: [RexOp1t8jccb#75]                   brnz v3, ebb1(v0)
 ; nextln: [Op1jmpb#eb]                        jump ebb1(v0)
 ; nextln: 

--- a/filetests/isa/x86/relax_branch.clif
+++ b/filetests/isa/x86/relax_branch.clif
@@ -21,95 +21,95 @@ function u0:2691(i32 [%rdi], i32 [%rsi], i64 vmctx [%r14]) -> i64 uext [%rax] ba
 @0005 [-]                           fallthrough ebb3(v0, v1)
 
                                 ebb3(v8: i32 [%rdi], v19: i32 [%rsi]):
-@0005 [RexOp1ldDisp8#808b,%rax]     v7 = load.i64 v2+48
-@0005 [RexOp1rcmp_ib#f083,%rflags]  v91 = ifcmp_imm v7, 0
-@0005 [trapif#00]                   trapif ne v91, interrupt
-[Op1umr#89,%rax]                    v105 = copy v8
-@000b [Op1r_ib#83,%rax]             v10 = iadd_imm v105, 1
-                                    v80 -> v10
-@0010 [Op1umr#89,%rcx]              v92 = uextend.i64 v8
-@0010 [RexOp1ld#808b,%rdx]          v93 = load.i64 notrap aligned readonly v2
-                                    v95 -> v93
-@0010 [Op2ldWithIndex#4be,%rcx]     v12 = sload8_complex.i32 v93+v92
-[Op1umr#89,%rbx]                    v106 = copy v12
-@0017 [Op1r_ib#40c1,%rbx]           v14 = ishl_imm v106, 24
-@001a [Op1r_ib#70c1,%rbx]           v16 = sshr_imm v14, 24
-[Op1umr#89,%rdi]                    v107 = copy v16
-@001f [Op1r_ib#83,%rdi]             v18 = iadd_imm v107, 32
-[RexOp1umr#89,%r8]                  v108 = copy v19
-@0026 [RexOp1r_ib#83,%r8]           v21 = iadd_imm v108, 1
-                                    v82 -> v21
-@002b [Op1umr#89,%rsi]              v94 = uextend.i64 v19
-@002b [Op2ldWithIndex#4be,%rdx]     v23 = sload8_complex.i32 v93+v94
-                                    v55 -> v23
-[Op1umr#89,%rsi]                    v109 = copy v23
-@0032 [Op1r_ib#40c1,%rsi]           v25 = ishl_imm v109, 24
-@0035 [Op1r_ib#70c1,%rsi]           v27 = sshr_imm v25, 24
-                                    v69 -> v27
-[RexOp1umr#89,%r9]                  v110 = copy v27
-@003a [RexOp1r_ib#83,%r9]           v29 = iadd_imm v110, 32
-                                    v68 -> v29
-@0042 [Op1r_ib#83,%rcx]             v31 = iadd_imm v12, -65
-@0045 [Op1r_ib#40c1,%rcx]           v33 = ishl_imm v31, 24
-@0048 [Op1r_ib#70c1,%rcx]           v35 = sshr_imm v33, 24
-@004c [Op1r_id#4081,%rcx]           v37 = band_imm v35, 255
-[Op1rcmp_ib#7083,%rflags]           v97 = ifcmp_imm v37, 26
-@0050 [Op1brib#70]                  brif sge v97, ebb6
-@0050 [-]                           fallthrough ebb10
+@0005 [RexOp1ldDisp8#808b,%rax]        v7 = load.i64 v2+48
+@0005 [DynRexOp1rcmp_ib#f083,%rflags]  v91 = ifcmp_imm v7, 0
+@0005 [trapif#00]                      trapif ne v91, interrupt
+[DynRexOp1umr#89,%rax]                 v105 = copy v8
+@000b [DynRexOp1r_ib#83,%rax]          v10 = iadd_imm v105, 1
+                                       v80 -> v10
+@0010 [Op1umr#89,%rcx]                 v92 = uextend.i64 v8
+@0010 [RexOp1ld#808b,%rdx]             v93 = load.i64 notrap aligned readonly v2
+                                       v95 -> v93
+@0010 [Op2ldWithIndex#4be,%rcx]        v12 = sload8_complex.i32 v93+v92
+[DynRexOp1umr#89,%rbx]                 v106 = copy v12
+@0017 [DynRexOp1r_ib#40c1,%rbx]        v14 = ishl_imm v106, 24
+@001a [DynRexOp1r_ib#70c1,%rbx]        v16 = sshr_imm v14, 24
+[DynRexOp1umr#89,%rdi]                 v107 = copy v16
+@001f [DynRexOp1r_ib#83,%rdi]          v18 = iadd_imm v107, 32
+[DynRexOp1umr#89,%r8]                  v108 = copy v19
+@0026 [DynRexOp1r_ib#83,%r8]           v21 = iadd_imm v108, 1
+                                       v82 -> v21
+@002b [Op1umr#89,%rsi]                 v94 = uextend.i64 v19
+@002b [Op2ldWithIndex#4be,%rdx]        v23 = sload8_complex.i32 v93+v94
+                                       v55 -> v23
+[DynRexOp1umr#89,%rsi]                 v109 = copy v23
+@0032 [DynRexOp1r_ib#40c1,%rsi]        v25 = ishl_imm v109, 24
+@0035 [DynRexOp1r_ib#70c1,%rsi]        v27 = sshr_imm v25, 24
+                                       v69 -> v27
+[DynRexOp1umr#89,%r9]                  v110 = copy v27
+@003a [DynRexOp1r_ib#83,%r9]           v29 = iadd_imm v110, 32
+                                       v68 -> v29
+@0042 [DynRexOp1r_ib#83,%rcx]          v31 = iadd_imm v12, -65
+@0045 [DynRexOp1r_ib#40c1,%rcx]        v33 = ishl_imm v31, 24
+@0048 [DynRexOp1r_ib#70c1,%rcx]        v35 = sshr_imm v33, 24
+@004c [DynRexOp1r_id#4081,%rcx]        v37 = band_imm v35, 255
+[DynRexOp1rcmp_ib#7083,%rflags]        v97 = ifcmp_imm v37, 26
+@0050 [Op1brib#70]                     brif sge v97, ebb6
+@0050 [-]                              fallthrough ebb10
 
                                 ebb10:
-[Op1umr#89,%rcx]                    v101 = copy v18
+[DynRexOp1umr#89,%rcx]              v101 = copy v18
 @0054 [Op1jmpb#eb]                  jump ebb5(v18, v101)
 
                                 ebb6:
-[Op1umr#89,%rcx]                    v102 = copy.i32 v16
+[DynRexOp1umr#89,%rcx]              v102 = copy.i32 v16
 @0059 [RexOp1rmov#89]               regmove v102, %rcx -> %rdi
 @0059 [RexOp1rmov#89]               regmove.i32 v16, %rbx -> %rcx
 @0059 [-]                           fallthrough ebb5(v102, v16)
 
                                 ebb5(v41: i32 [%rdi], v84: i32 [%rcx]):
                                     v83 -> v84
-@005d [Op1r_id#4081,%rdi]           v43 = band_imm v41, 255
-@0062 [Op1r_ib#40c1,%rdi]           v45 = ishl_imm v43, 24
+@005d [DynRexOp1r_id#4081,%rdi]     v43 = band_imm v41, 255
+@0062 [DynRexOp1r_ib#40c1,%rdi]     v45 = ishl_imm v43, 24
                                     v52 -> v45
 @0065 [RexOp1rmov#89]               regmove v45, %rdi -> %rbx
-@0065 [Op1r_ib#70c1,%rbx]           v47 = sshr_imm v45, 24
+@0065 [DynRexOp1r_ib#70c1,%rbx]     v47 = sshr_imm v45, 24
                                     v54 -> v47
 @0068 [RexOp1rmov#89]               regmove v47, %rbx -> %rdi
-@0068 [Op1icscc_ib#7083,%rbx]       v49 = icmp_imm ne v47, 0
+@0068 [DynRexOp1icscc_ib#7083,%rbx] v49 = icmp_imm ne v47, 0
 @0068 [RexOp2urm_noflags#4b6,%r10]  v50 = bint.i32 v49
-@0076 [Op1r_ib#83,%rdx]             v57 = iadd_imm.i32 v23, -65
-@0079 [Op1r_ib#40c1,%rdx]           v59 = ishl_imm v57, 24
-@007c [Op1r_ib#70c1,%rdx]           v61 = sshr_imm v59, 24
-@0080 [Op1r_id#4081,%rdx]           v63 = band_imm v61, 255
-[Op1rcmp_ib#7083,%rflags]           v98 = ifcmp_imm v63, 26
+@0076 [DynRexOp1r_ib#83,%rdx]       v57 = iadd_imm.i32 v23, -65
+@0079 [DynRexOp1r_ib#40c1,%rdx]     v59 = ishl_imm v57, 24
+@007c [DynRexOp1r_ib#70c1,%rdx]     v61 = sshr_imm v59, 24
+@0080 [DynRexOp1r_id#4081,%rdx]     v63 = band_imm v61, 255
+[DynRexOp1rcmp_ib#7083,%rflags]     v98 = ifcmp_imm v63, 26
 @0084 [RexOp1rmov#89]               regmove v47, %rdi -> %rbx
 @0084 [Op1brib#70]                  brif sge v98, ebb8
 @0084 [-]                           fallthrough ebb11
 
                                 ebb11:
-[RexOp1umr#89,%rdx]                 v103 = copy.i32 v29
+[DynRexOp1umr#89,%rdx]              v103 = copy.i32 v29
 @0088 [Op1jmpb#eb]                  jump ebb7(v29, v10, v21, v103)
 
                                 ebb8:
-[Op1umr#89,%rdx]                    v104 = copy.i32 v27
+[DynRexOp1umr#89,%rdx]              v104 = copy.i32 v27
 @008d [RexOp1rmov#89]               regmove v104, %rdx -> %r9
 @008d [RexOp1rmov#89]               regmove.i32 v27, %rsi -> %rdx
 @008d [-]                           fallthrough ebb7(v104, v10, v21, v27)
 
                                 ebb7(v67: i32 [%r9], v79: i32 [%rax], v81: i32 [%r8], v87: i32 [%rdx]):
-@0091 [RexOp1r_id#4081,%r9]         v71 = band_imm v67, 255
-@0094 [RexOp1r_ib#40c1,%r9]         v73 = ishl_imm v71, 24
-@0097 [RexOp1r_ib#70c1,%r9]         v75 = sshr_imm v73, 24
-@0098 [RexOp1icscc#39,%rbx]         v76 = icmp.i32 eq v47, v75
-@0098 [Op2urm_noflags_abcd#4b6,%rbx] v77 = bint.i32 v76
-@0099 [RexOp1rr#21,%r10]            v78 = band.i32 v50, v77
-@009a [RexOp1tjccb#74]              brz v78, ebb9
-@009a [-]                           fallthrough ebb12
+@0091 [DynRexOp1r_id#4081,%r9]           v71 = band_imm v67, 255
+@0094 [DynRexOp1r_ib#40c1,%r9]           v73 = ishl_imm v71, 24
+@0097 [DynRexOp1r_ib#70c1,%r9]           v75 = sshr_imm v73, 24
+@0098 [DynRexOp1icscc#39,%rbx]           v76 = icmp.i32 eq v47, v75
+@0098 [Op2urm_noflags_abcd#4b6,%rbx]     v77 = bint.i32 v76
+@0099 [DynRexOp1rr#21,%r10]              v78 = band.i32 v50, v77
+@009a [DynRexOp1tjccb#74]                brz v78, ebb9
+@009a [-]                                fallthrough ebb12
 
                                 ebb12:
-[RexOp1umr#89,%rcx]                 v99 = copy v81
-[Op1umr#89,%rdx]                    v100 = copy v79
+[DynRexOp1umr#89,%rcx]              v99 = copy v81
+[DynRexOp1umr#89,%rdx]              v100 = copy v79
 @00a4 [RexOp1rmov#89]               regmove v100, %rdx -> %rdi
 @00a4 [RexOp1rmov#89]               regmove v99, %rcx -> %rsi
 @00a4 [Op1jmpd#e9]                  jump ebb3(v100, v99); bin: e9 ffffff2d
@@ -118,9 +118,9 @@ function u0:2691(i32 [%rdi], i32 [%rsi], i64 vmctx [%r14]) -> i64 uext [%rax] ba
 @00a7 [-]                           fallthrough ebb4
 
                                 ebb4:
-@00ad [Op1r_id#4081,%rcx]           v86 = band_imm.i32 v84, 255
-@00b3 [Op1r_id#4081,%rdx]           v89 = band_imm.i32 v87, 255
-@00b4 [Op1rr#29,%rcx]               v90 = isub v86, v89
+@00ad [DynRexOp1r_id#4081,%rcx]     v86 = band_imm.i32 v84, 255
+@00b3 [DynRexOp1r_id#4081,%rdx]     v89 = band_imm.i32 v87, 255
+@00b4 [DynRexOp1rr#29,%rcx]         v90 = isub v86, v89
 @00b5 [-]                           fallthrough ebb2(v90)
 
                                 ebb2(v5: i32 [%rcx]):

--- a/filetests/isa/x86/shrink-multiple-uses.clif
+++ b/filetests/isa/x86/shrink-multiple-uses.clif
@@ -4,7 +4,7 @@ target x86_64
 
 function %test_multiple_uses(i32 [%rdi]) -> i32 {
 ebb0(v0: i32 [%rdi]):
-[Op1rcmp_ib#7083,%rflags]           v3 = ifcmp_imm v0, 0
+[DynRexOp1rcmp_ib#7083,%rflags]     v3 = ifcmp_imm v0, 0
 [Op2seti_abcd#490,%rax]             v1 = trueif eq v3
 [RexOp2urm_noflags#4b6,%rax]        v2 = bint.i32 v1
 [Op1brib#70]                        brif eq v3, ebb1

--- a/filetests/postopt/basic.clif
+++ b/filetests/postopt/basic.clif
@@ -5,9 +5,9 @@ target i686
 
 function %br_icmp(i32, i32) -> i32 {
 ebb0(v0: i32, v1: i32):
-[Op1icscc#39,%rdx]  v2 = icmp slt v0, v1
-[Op1t8jccd_long#85] brnz v2, ebb1
-[Op1jmpb#eb]        jump ebb2
+[DynRexOp1icscc#39,%rdx]  v2 = icmp slt v0, v1
+[Op1t8jccd_long#85]       brnz v2, ebb1
+[Op1jmpb#eb]              jump ebb2
 
 ebb2:
 [Op1ret#c3]         return v1
@@ -35,9 +35,9 @@ ebb1:
 
 function %br_icmp_inverse(i32, i32) -> i32 {
 ebb0(v0: i32, v1: i32):
-[Op1icscc#39,%rdx]  v2 = icmp slt v0, v1
-[Op1t8jccd_long#84] brz v2, ebb1
-[Op1jmpb#eb]        jump ebb2
+[DynRexOp1icscc#39,%rdx]  v2 = icmp slt v0, v1
+[Op1t8jccd_long#84]       brz v2, ebb1
+[Op1jmpb#eb]              jump ebb2
 
 ebb2:
 [Op1ret#c3]         return v1
@@ -65,9 +65,9 @@ ebb1:
 
 function %br_icmp_imm(i32, i32) -> i32 {
 ebb0(v0: i32, v1: i32):
-[Op1icscc_ib#7083]  v2 = icmp_imm slt v0, 2
-[Op1t8jccd_long#84] brz v2, ebb1
-[Op1jmpb#eb]        jump ebb2
+[DynRexOp1icscc_ib#7083]  v2 = icmp_imm slt v0, 2
+[Op1t8jccd_long#84]       brz v2, ebb1
+[Op1jmpb#eb]              jump ebb2
 
 ebb2:
 [Op1ret#c3]         return v1

--- a/filetests/postopt/complex_memory_ops.clif
+++ b/filetests/postopt/complex_memory_ops.clif
@@ -3,7 +3,7 @@ target x86_64
 
 function %dual_loads(i64, i64) -> i64 {
 ebb0(v0: i64, v1: i64):
-[RexOp1rr#8001]    v3 = iadd v0, v1
+[DynRexOp1rr#8001] v3 = iadd v0, v1
                    v4 = load.i64 v3
                    v5 = uload8.i64 v3
                    v6 = sload8.i64 v3
@@ -29,7 +29,7 @@ ebb0(v0: i64, v1: i64):
 
 function %dual_loads2(i64, i64) -> i64 {
 ebb0(v0: i64, v1: i64):
-[RexOp1rr#8001]    v3 = iadd v0, v1
+[DynRexOp1rr#8001] v3 = iadd v0, v1
                    v4 = load.i64 v3+1
                    v5 = uload8.i64 v3+1
                    v6 = sload8.i64 v3+1
@@ -55,7 +55,7 @@ ebb0(v0: i64, v1: i64):
 
 function %dual_stores(i64, i64, i64) {
 ebb0(v0: i64, v1: i64, v2: i64):
-[RexOp1rr#8001]    v3 = iadd v0, v1
+[DynRexOp1rr#8001] v3 = iadd v0, v1
 [RexOp1st#8089]    store.i64 v2, v3
 [RexOp1st#88]      istore8.i64 v2, v3
 [RexMp1st#189]     istore16.i64 v2, v3
@@ -75,7 +75,7 @@ ebb0(v0: i64, v1: i64, v2: i64):
 
 function %dual_stores2(i64, i64, i64) {
 ebb0(v0: i64, v1: i64, v2: i64):
-[RexOp1rr#8001]         v3 = iadd v0, v1
+[DynRexOp1rr#8001] v3 = iadd v0, v1
 [RexOp1stDisp8#8089]    store.i64 v2, v3+1
 [RexOp1stDisp8#88]      istore8.i64 v2, v3+1
 [RexMp1stDisp8#189]     istore16.i64 v2, v3+1

--- a/filetests/regalloc/coloring-227.clif
+++ b/filetests/regalloc/coloring-227.clif
@@ -8,7 +8,7 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
                           ebb0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i64):
 [RexOp1pu_id#b8]              v5 = iconst.i32 0
 [RexOp1pu_id#b8]              v6 = iconst.i32 0
-[RexOp1tjccb#74]              brz v6, ebb10
+[DynRexOp1tjccb#74]           brz v6, ebb10
 [Op1jmpb#eb]                  jump ebb3(v5, v5, v5, v5, v5, v5, v0, v1, v2, v3)
 
                           ebb3(v15: i32, v17: i32, v25: i32, v31: i32, v40: i32, v47: i32, v54: i32, v61: i32, v68: i32, v75: i32):
@@ -16,33 +16,33 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
 
                           ebb6:
 [RexOp1pu_id#b8]              v8 = iconst.i32 0
-[RexOp1tjccb#75]              brnz v8, ebb5
+[DynRexOp1tjccb#75]           brnz v8, ebb5
 [Op1jmpb#eb]                  jump ebb20
 
                           ebb20:
 [RexOp1pu_id#b8]              v9 = iconst.i32 0
 [RexOp1pu_id#b8]              v11 = iconst.i32 0
-[RexOp1icscc#39]              v12 = icmp.i32 eq v15, v11
+[DynRexOp1icscc#39]           v12 = icmp.i32 eq v15, v11
 [RexOp2urm_noflags#4b6]       v13 = bint.i32 v12
-[RexOp1rr#21]                 v14 = band v9, v13
-[RexOp1tjccb#75]              brnz v14, ebb6
+[DynRexOp1rr#21]              v14 = band v9, v13
+[DynRexOp1tjccb#75]           brnz v14, ebb6
 [Op1jmpb#eb]                  jump ebb7
 
                           ebb7:
-[RexOp1tjccb#74]              brz.i32 v17, ebb8
+[DynRexOp1tjccb#74]           brz.i32 v17, ebb8
 [Op1jmpb#eb]                  jump ebb17
 
                           ebb17:
 [RexOp1pu_id#b8]              v18 = iconst.i32 0
-[RexOp1tjccb#74]              brz v18, ebb9
+[DynRexOp1tjccb#74]           brz v18, ebb9
 [Op1jmpb#eb]                  jump ebb16
 
                           ebb16:
 [RexOp1pu_id#b8]              v21 = iconst.i32 0
 [RexOp1umr#89]                v79 = uextend.i64 v5
-[RexOp1r_ib#8083]             v80 = iadd_imm.i64 v4, 0
+[DynRexOp1r_ib#8083]          v80 = iadd_imm.i64 v4, 0
 [RexOp1ld#808b]               v81 = load.i64 v80
-[RexOp1rr#8001]               v22 = iadd v81, v79
+[DynRexOp1rr#8001]            v22 = iadd v81, v79
 [RexMp1st#189]                istore16 v21, v22
 [Op1jmpb#eb]                  jump ebb9
 
@@ -52,8 +52,8 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
                           ebb8:
 [RexOp1pu_id#b8]              v27 = iconst.i32 3
 [RexOp1pu_id#b8]              v28 = iconst.i32 4
-[RexOp1rr#09]                 v35 = bor.i32 v31, v13
-[RexOp1tjccb#75]              brnz v35, ebb15(v27)
+[DynRexOp1rr#09]              v35 = bor.i32 v31, v13
+[DynRexOp1tjccb#75]           brnz v35, ebb15(v27)
 [Op1jmpb#eb]                  jump ebb15(v28)
 
                           ebb15(v36: i32):
@@ -71,24 +71,24 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
 
                           ebb2(v7: i32, v45: i32, v52: i32, v59: i32, v66: i32, v73: i32):
 [RexOp1pu_id#b8]              v44 = iconst.i32 0
-[RexOp1tjccb#74]              brz v44, ebb12
+[DynRexOp1tjccb#74]           brz v44, ebb12
 [Op1jmpb#eb]                  jump ebb18
 
                           ebb18:
 [RexOp1pu_id#b8]              v50 = iconst.i32 11
-[RexOp1tjccb#74]              brz v50, ebb14
+[DynRexOp1tjccb#74]           brz v50, ebb14
 [Op1jmpb#eb]                  jump ebb19
 
                           ebb19:
 [RexOp1umr#89]                v82 = uextend.i64 v52
-[RexOp1r_ib#8083]             v83 = iadd_imm.i64 v4, 0
+[DynRexOp1r_ib#8083]          v83 = iadd_imm.i64 v4, 0
 [RexOp1ld#808b]               v84 = load.i64 v83
-[RexOp1rr#8001]               v57 = iadd v84, v82
+[DynRexOp1rr#8001]            v57 = iadd v84, v82
 [RexOp1ld#8b]                 v58 = load.i32 v57
 [RexOp1umr#89]                v85 = uextend.i64 v58
-[RexOp1r_ib#8083]             v86 = iadd_imm.i64 v4, 0
+[DynRexOp1r_ib#8083]          v86 = iadd_imm.i64 v4, 0
 [RexOp1ld#808b]               v87 = load.i64 v86
-[RexOp1rr#8001]               v64 = iadd v87, v85
+[DynRexOp1rr#8001]            v64 = iadd v87, v85
 [RexOp1st#88]                 istore8 v59, v64
 [RexOp1pu_id#b8]              v65 = iconst.i32 0
 [Op1jmpb#eb]                  jump ebb13(v65)
@@ -98,9 +98,9 @@ function %pr227(i32 [%rdi], i32 [%rsi], i32 [%rdx], i32 [%rcx], i64 vmctx [%r8])
 
                           ebb13(v51: i32):
 [RexOp1umr#89]                v88 = uextend.i64 v45
-[RexOp1r_ib#8083]             v89 = iadd_imm.i64 v4, 0
+[DynRexOp1r_ib#8083]          v89 = iadd_imm.i64 v4, 0
 [RexOp1ld#808b]               v90 = load.i64 v89
-[RexOp1rr#8001]               v71 = iadd v90, v88
+[DynRexOp1rr#8001]            v71 = iadd v90, v88
 [RexOp1st#89]                 store v51, v71
 [Op1jmpb#eb]                  jump ebb12
 

--- a/filetests/verifier/flags.clif
+++ b/filetests/verifier/flags.clif
@@ -4,7 +4,7 @@ target i686
 ; Simple, correct use of CPU flags.
 function %simple(i32) -> i32 {
                     ebb0(v0: i32):
-    [Op1rcmp#39]              v1 = ifcmp v0, v0
+    [DynRexOp1rcmp#39]        v1 = ifcmp v0, v0
     [Op2seti_abcd#490]        v2 = trueif ugt v1
     [Op2urm_noflags_abcd#4b6] v3 = bint.i32 v2
     [Op1ret#c3]               return v3
@@ -13,7 +13,7 @@ function %simple(i32) -> i32 {
 ; Overlapping flag values of different types.
 function %overlap(i32, f32) -> i32 {
                     ebb0(v0: i32, v1: f32):
-    [Op1rcmp#39]              v2 = ifcmp v0, v0
+    [DynRexOp1rcmp#39]        v2 = ifcmp v0, v0
     [Op2fcmp#42e]             v3 = ffcmp v1, v1
     [Op2setf_abcd#490]        v4 = trueff gt v3 ; error: conflicting live CPU flags: v2 and v3
     [Op2seti_abcd#490]        v5 = trueif ugt v2
@@ -25,8 +25,8 @@ function %overlap(i32, f32) -> i32 {
 ; CPU flags clobbered by arithmetic.
 function %clobbered(i32) -> i32 {
                     ebb0(v0: i32):
-    [Op1rcmp#39]              v1 = ifcmp v0, v0
-    [Op1rr#01]                v2 = iadd v0, v0 ; error: encoding clobbers live CPU flags in v1
+    [DynRexOp1rcmp#39]        v1 = ifcmp v0, v0
+    [DynRexOp1rr#01]          v2 = iadd v0, v0 ; error: encoding clobbers live CPU flags in v1
     [Op2seti_abcd#490]        v3 = trueif ugt v1
     [Op2urm_noflags_abcd#4b6] v4 = bint.i32 v3
     [Op1ret#c3]               return v4
@@ -35,7 +35,7 @@ function %clobbered(i32) -> i32 {
 ; CPU flags not clobbered by load.
 function %live_across_load(i32) -> i32 {
                     ebb0(v0: i32):
-    [Op1rcmp#39]              v1 = ifcmp v0, v0
+    [DynRexOp1rcmp#39]        v1 = ifcmp v0, v0
     [Op1ld#8b]                v2 = load.i32 v0
     [Op2seti_abcd#490]        v3 = trueif ugt v1
     [Op2urm_noflags_abcd#4b6] v4 = bint.i32 v3
@@ -45,7 +45,7 @@ function %live_across_load(i32) -> i32 {
 ; Correct use of CPU flags across EBB.
 function %live_across_ebb(i32) -> i32 {
                           ebb0(v0: i32):
-    [Op1rcmp#39]              v1 = ifcmp v0, v0
+    [DynRexOp1rcmp#39]        v1 = ifcmp v0, v0
     [Op1jmpb#eb]              jump ebb1
                           ebb1:
     [Op2seti_abcd#490]        v2 = trueif ugt v1
@@ -61,14 +61,14 @@ function %live_across_ebb_backwards(i32) -> i32 {
     [Op2urm_noflags_abcd#4b6] v3 = bint.i32 v2
     [Op1ret#c3]               return v3
                           ebb2:
-    [Op1rcmp#39]              v1 = ifcmp v0, v0
+    [DynRexOp1rcmp#39]        v1 = ifcmp v0, v0
     [Op1jmpb#eb]              jump ebb1
 }
 
 ; Flags live into loop.
 function %live_into_loop(i32) -> i32 {
                     ebb0(v0: i32):
-    [Op1rcmp#39]        v1 = ifcmp v0, v0
+    [DynRexOp1rcmp#39]  v1 = ifcmp v0, v0
     [Op1jmpb#eb]        jump ebb1
                     ebb1:
     [Op2seti_abcd#490]  v2 = trueif ugt v1


### PR DESCRIPTION
- [x] This has been discussed in https://github.com/bytecodealliance/cranelift/pull/1173. The original approach was to avoid using Templates, but it was extremely complicated. This approach is much better to reduce the number of recipes.
- [x] This patch adds a third mode for templates: REX inference is requestable at template instantiation time. This reduces the number of recipes by removing rex()/nonrex() redundancy for many instructions. In the common case of `i32_i64` and `b32_b64` encodings, this inferrable-REX mode is used.
- [x] This PR contains test cases, if meaningful. (It's covered by the filetests.)
- [x] A reviewer from the core maintainer team has been assigned for this PR.

I understand that this is work will likely be overridden by what Chris is working on. However, I believe this is still a good idea to land, because:

1. It is a strict decrease in the number of recipes.
2. It makes more of the REX-related code explicit, and therefore visible. Removing implicit logic makes the code easier to reason about, and therefore easier to refactor later.
3. Because the recipe count decreases, there should be a small performance improvement due to faster encoding -- there are fewer options from which to select.
4. The transformation is fairly mechanical and I believe not difficult to review.

This invalidates the work in https://github.com/bytecodealliance/cranelift/pull/1173. That approach did not work because it tried to avoid using Templates. Removing templates at the same time as making this change resulted in too many moving parts -- it was overly complicated and error-prone.