### PR TITLE
Merge emit_small_memcpy and emit_small_memmove

### DIFF
--- a/cranelift-frontend/src/frontend.rs
+++ b/cranelift-frontend/src/frontend.rs
@@ -633,7 +633,7 @@ impl<'a> FunctionBuilder<'a> {
     ///
     /// The following properties must hold to prevent UB:
     ///
-    /// * `src_align` and `dest_align` are an upper-bound on the alignment of `src` cq `dest`.
+    /// * `src_align` and `dest_align` are an upper-bound on the alignment of `src` respectively `dest`.
     /// * If `non_overlapping` is true, then this must be correct.
     pub fn emit_small_memory_copy(
         &mut self,

--- a/cranelift-frontend/src/frontend.rs
+++ b/cranelift-frontend/src/frontend.rs
@@ -1,7 +1,6 @@
 //! A frontend for building Cranelift IR from other languages.
 use crate::ssa::{Block, SSABuilder, SideEffects};
 use crate::variable::Variable;
-use alloc::vec::Vec;
 use cranelift_codegen::cursor::{Cursor, FuncCursor};
 use cranelift_codegen::entity::{EntitySet, SecondaryMap};
 use cranelift_codegen::ir;
@@ -628,8 +627,15 @@ impl<'a> FunctionBuilder<'a> {
         self.ins().call(libc_memcpy, &[dest, src, size]);
     }
 
-    /// Optimised memcpy for small copies.
-    pub fn emit_small_memcpy(
+    /// Optimised memcpy or memmove for small copies.
+    ///
+    /// # Codegen safety
+    ///
+    /// The following properties must hold to prevent UB:
+    ///
+    /// * `src_align` and `dest_align` are an upper-bound on the alignment of `src` cq `dest`.
+    /// * If `non_overlapping` is true, then this must be correct.
+    pub fn emit_small_memory_copy(
         &mut self,
         config: TargetFrontendConfig,
         dest: Value,
@@ -637,6 +643,7 @@ impl<'a> FunctionBuilder<'a> {
         size: u64,
         dest_align: u8,
         src_align: u8,
+        non_overlapping: bool,
     ) {
         // Currently the result of guess work, not actual profiling.
         const THRESHOLD: u64 = 4;
@@ -665,16 +672,27 @@ impl<'a> FunctionBuilder<'a> {
 
         if load_and_store_amount > THRESHOLD {
             let size_value = self.ins().iconst(config.pointer_type(), size as i64);
-            self.call_memcpy(config, dest, src, size_value);
+            if non_overlapping {
+                self.call_memcpy(config, dest, src, size_value);
+            } else {
+                self.call_memmove(config, dest, src, size_value);
+            }
             return;
         }
 
         let mut flags = MemFlags::new();
         flags.set_aligned();
 
-        for i in 0..load_and_store_amount {
-            let offset = (access_size * i) as i32;
-            let value = self.ins().load(int_type, flags, src, offset);
+        // Load all of the memory first. This is necessary in case `dest` overlaps.
+        // It can also improve performance a bit.
+        let registers: smallvec::SmallVec<[_; THRESHOLD as usize]> = (0..load_and_store_amount)
+            .map(|i| {
+                let offset = (access_size * i) as i32;
+                (self.ins().load(int_type, flags, src, offset), offset)
+            })
+            .collect();
+
+        for (value, offset) in registers {
             self.ins().store(flags, value, dest, offset);
         }
     }
@@ -799,55 +817,6 @@ impl<'a> FunctionBuilder<'a> {
         });
 
         self.ins().call(libc_memmove, &[dest, source, size]);
-    }
-
-    /// Optimised memmove for small moves.
-    pub fn emit_small_memmove(
-        &mut self,
-        config: TargetFrontendConfig,
-        dest: Value,
-        src: Value,
-        size: u64,
-        dest_align: u8,
-        src_align: u8,
-    ) {
-        // Currently the result of guess work, not actual profiling.
-        const THRESHOLD: u64 = 4;
-
-        let access_size = greatest_divisible_power_of_two(size);
-        assert!(
-            access_size.is_power_of_two(),
-            "`size` is not a power of two"
-        );
-        assert!(
-            access_size >= u64::from(::core::cmp::min(src_align, dest_align)),
-            "`size` is smaller than `dest` and `src`'s alignment value."
-        );
-        let load_and_store_amount = size / access_size;
-
-        if load_and_store_amount > THRESHOLD {
-            let size_value = self.ins().iconst(config.pointer_type(), size as i64);
-            self.call_memmove(config, dest, src, size_value);
-            return;
-        }
-
-        let mut flags = MemFlags::new();
-        flags.set_aligned();
-
-        // Load all of the memory first in case `dest` overlaps.
-        let registers: Vec<_> = (0..load_and_store_amount)
-            .map(|i| {
-                let offset = (access_size * i) as i32;
-                (
-                    self.ins().load(config.pointer_type(), flags, src, offset),
-                    offset,
-                )
-            })
-            .collect();
-
-        for (value, offset) in registers {
-            self.ins().store(flags, value, dest, offset);
-        }
     }
 }
 
@@ -1106,7 +1075,7 @@ ebb0:
             let src = builder.use_var(x);
             let dest = builder.use_var(y);
             let size = 8;
-            builder.emit_small_memcpy(target.frontend_config(), dest, src, size, 8, 8);
+            builder.emit_small_memory_copy(target.frontend_config(), dest, src, size, 8, 8, true);
             builder.ins().return_(&[dest]);
 
             builder.seal_all_blocks();
@@ -1163,7 +1132,7 @@ ebb0:
             let src = builder.use_var(x);
             let dest = builder.use_var(y);
             let size = 8192;
-            builder.emit_small_memcpy(target.frontend_config(), dest, src, size, 8, 8);
+            builder.emit_small_memory_copy(target.frontend_config(), dest, src, size, 8, 8, true);
             builder.ins().return_(&[dest]);
 
             builder.seal_all_blocks();


### PR DESCRIPTION
- [x] This has been discussed in issue #..., or if not, please tell us why
  here. This is mostly a cleanup.
- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first. They share a lot of code. Also by performing all loads before all stores, the performance of the simple-raytracer cg_clif benchmark increases by 1%.
- [x] This PR contains test cases, if meaningful. N/A
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. <strike>The list of suggested reviewers on the right can help you.</strike> (no list for non members)

<!-- Please ensure all communication adheres to the [code of
conduct](https://github.com/CraneStation/cranelift/blob/master/CODE_OF_CONDUCT.md). -->
