### PR TITLE
Encode stack load store

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/encodings.rs
+++ b/cranelift-codegen/meta/src/cdsl/encodings.rs
@@ -69,7 +69,11 @@ impl EncodingBuilder {
                 assert_eq!(
                     inst.value_types.len(),
                     other_typevars.len() + 1,
-                    "partially bound polymorphic instruction"
+                    "partially bound polymorphic instruction {} \
+                    with value_types {:?} and immediate values {:?}",
+                    inst.inst.name,
+                    inst.value_types,
+                    inst.immediate_values,
                 );
 
                 // Add secondary type variables to the instruction predicate.
@@ -112,7 +116,8 @@ impl EncodingBuilder {
             InstSpec::Inst(inst) => {
                 assert!(
                     inst.polymorphic_info.is_none(),
-                    "unbound polymorphic instruction"
+                    "unbound polymorphic instruction {}",
+                    inst.name,
                 );
                 (None, None)
             }

--- a/cranelift-codegen/meta/src/cdsl/encodings.rs
+++ b/cranelift-codegen/meta/src/cdsl/encodings.rs
@@ -70,7 +70,7 @@ impl EncodingBuilder {
                     inst.value_types.len(),
                     other_typevars.len() + 1,
                     "partially bound polymorphic instruction {} \
-                    with value_types {:?} and immediate values {:?}",
+                     with value_types {:?} and immediate values {:?}",
                     inst.inst.name,
                     inst.value_types,
                     inst.immediate_values,

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -374,7 +374,7 @@ impl InstructionBuilder {
 }
 
 /// A thin wrapper like Option<ValueType>, but with more precise semantics.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum ValueTypeOrAny {
     ValueType(ValueType),
     Any,
@@ -442,7 +442,7 @@ impl From<Immediate> for BindParameter {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum Immediate {
     // When needed, this enum should be expanded to include other immediate types (e.g. u8, u128).
     IntCC(IntCC),

--- a/cranelift-codegen/meta/src/cdsl/recipes.rs
+++ b/cranelift-codegen/meta/src/cdsl/recipes.rs
@@ -17,7 +17,7 @@ use crate::cdsl::settings::SettingPredicateNumber;
 ///
 /// Register instances can be created with the constructor, or accessed as
 /// attributes on the register class: `GPR.rcx`.
-#[derive(Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub(crate) struct Register {
     pub regclass: RegClassIndex,
     pub unit: u8,
@@ -33,7 +33,7 @@ impl Register {
 ///
 /// A `Stack` object can be used to indicate an operand constraint for a value
 /// operand that must live in a stack slot.
-#[derive(Copy, Clone, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq)]
 pub(crate) struct Stack {
     pub regclass: RegClassIndex,
 }
@@ -54,7 +54,7 @@ pub(crate) struct BranchRange {
     pub range: u64,
 }
 
-#[derive(Copy, Clone, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq)]
 pub(crate) enum OperandConstraint {
     RegClass(RegClassIndex),
     FixedReg(Register),
@@ -261,8 +261,8 @@ impl EncodingRecipeBuilder {
             assert!(
                 operands_in.len() == self.format.num_value_operands,
                 format!(
-                    "missing operand constraints for recipe {} (format {})",
-                    self.name, self.format.name
+                    "missing operand constraints for recipe {} (format {}, existing operand constraints: {:?}, required operand constraints: {})",
+                    self.name, self.format.name, operands_in, self.format.num_value_operands,
                 )
             );
         }

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -2191,7 +2191,10 @@ fn define_entity_ref(
 
     // Stack accesses.
     e.enc32(stack_addr.bind(I32), rec_spaddr_ld_id.opcodes(&LEA));
-    e.enc64(stack_addr.bind(I64), rec_spaddr_ld_id.opcodes(&LEA).rex().w());
+    e.enc64(
+        stack_addr.bind(I64),
+        rec_spaddr_ld_id.opcodes(&LEA).rex().w(),
+    );
     e.enc_i32_i64_explicit_rex(stack_load, rec_spaddr_ld_id.opcodes(&MOV_LOAD));
     e.enc_i32_i64_explicit_rex(stack_store, rec_spst_id.opcodes(&MOV_STORE));
 }

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -2191,7 +2191,7 @@ fn define_entity_ref(
 
     // Stack accesses.
     e.enc32(stack_addr.bind(I32), rec_spaddr_ld_id.opcodes(&LEA));
-    e.enc64(stack_addr.bind(I64), rec_spaddr_ld_id.opcodes(&LEA));
+    e.enc64(stack_addr.bind(I64), rec_spaddr_ld_id.opcodes(&LEA).rex().w());
     e.enc_i32_i64_explicit_rex(stack_load, rec_spaddr_ld_id.opcodes(&MOV_LOAD));
     e.enc_i32_i64_explicit_rex(stack_store, rec_spst_id.opcodes(&MOV_STORE));
 }

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -2089,6 +2089,8 @@ fn define_entity_ref(
     // Shorthands for instructions.
     let func_addr = shared.by_name("func_addr");
     let stack_addr = shared.by_name("stack_addr");
+    let stack_load = shared.by_name("stack_load");
+    let stack_store = shared.by_name("stack_store");
     let symbol_value = shared.by_name("symbol_value");
 
     // Shorthands for recipes.
@@ -2102,8 +2104,8 @@ fn define_entity_ref(
     let rec_gvaddr8 = r.template("gvaddr8");
     let rec_pcrel_fnaddr8 = r.template("pcrel_fnaddr8");
     let rec_pcrel_gvaddr8 = r.template("pcrel_gvaddr8");
-    let rec_spaddr4_id = r.template("spaddr4_id");
-    let rec_spaddr8_id = r.template("spaddr8_id");
+    let rec_spaddr_ld_id = r.template("spaddr_ld_id");
+    let rec_spst_id = r.template("spst_id");
 
     // Predicates shorthands.
     let all_ones_funcaddrs_and_not_is_pic =
@@ -2187,12 +2189,11 @@ fn define_entity_ref(
         is_pic,
     );
 
-    // Stack addresses.
-    //
-    // TODO: Add encoding rules for stack_load and stack_store, so that they
-    // don't get legalized to stack_addr + load/store.
-    e.enc32(stack_addr.bind(I32), rec_spaddr4_id.opcodes(&LEA));
-    e.enc64(stack_addr.bind(I64), rec_spaddr8_id.opcodes(&LEA).rex().w());
+    // Stack accesses.
+    e.enc32(stack_addr.bind(I32), rec_spaddr_ld_id.opcodes(&LEA));
+    e.enc64(stack_addr.bind(I64), rec_spaddr_ld_id.opcodes(&LEA));
+    e.enc_i32_i64_explicit_rex(stack_load, rec_spaddr_ld_id.opcodes(&MOV_LOAD));
+    e.enc_i32_i64_explicit_rex(stack_store, rec_spst_id.opcodes(&MOV_STORE));
 }
 
 /// Control flow opcodes.

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -1422,6 +1422,7 @@ pub(crate) fn define<'shared>(
             .operands_in(vec![gpr])
             .emit(
                 r#"
+                        sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
                         let sp = StackRef::sp(stack_slot, &func.stack_slots);
                         let base = stk_base(sp.base);
                         {{PUT_OP}}(bits, rex2(base, in_reg0), sink);

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -1392,40 +1392,46 @@ pub(crate) fn define<'shared>(
             ),
     );
 
-    // Stack addresses.
+    // Stack accesses.
     //
     // TODO Alternative forms for 8-bit immediates, when applicable.
 
-    recipes.add_template_recipe(
-        EncodingRecipeBuilder::new("spaddr4_id", &formats.stack_load, 6)
-            .operands_out(vec![gpr])
-            .emit(
-                r#"
-                    let sp = StackRef::sp(stack_slot, &func.stack_slots);
-                    let base = stk_base(sp.base);
-                    {{PUT_OP}}(bits, rex2(out_reg0, base), sink);
-                    modrm_sib_disp8(out_reg0, sink);
-                    sib_noindex(base, sink);
-                    let imm : i32 = offset.into();
-                    sink.put4(sp.offset.checked_add(imm).unwrap() as u32);
-                "#,
-            ),
+    recipes.add_template(
+        Template::new(
+            EncodingRecipeBuilder::new("spaddr_ld_id", &formats.stack_load, 6)
+                .operands_out(vec![gpr])
+                .emit(
+                    r#"
+                        let sp = StackRef::sp(stack_slot, &func.stack_slots);
+                        let base = stk_base(sp.base);
+                        {{PUT_OP}}(bits, rex2(base, out_reg0), sink);
+                        modrm_sib_disp32(out_reg0, sink);
+                        sib_noindex(base, sink);
+                        let imm : i32 = offset.into();
+                        sink.put4(sp.offset.checked_add(imm).unwrap() as u32);
+                    "#,
+                ),
+            regs
+        )
     );
 
-    recipes.add_template_recipe(
-        EncodingRecipeBuilder::new("spaddr8_id", &formats.stack_load, 6)
-            .operands_out(vec![gpr])
-            .emit(
-                r#"
-                    let sp = StackRef::sp(stack_slot, &func.stack_slots);
-                    let base = stk_base(sp.base);
-                    {{PUT_OP}}(bits, rex2(base, out_reg0), sink);
-                    modrm_sib_disp32(out_reg0, sink);
-                    sib_noindex(base, sink);
-                    let imm : i32 = offset.into();
-                    sink.put4(sp.offset.checked_add(imm).unwrap() as u32);
-                "#,
-            ),
+    recipes.add_template(
+        Template::new(
+            EncodingRecipeBuilder::new("spst_id", &formats.stack_store, 6)
+                .operands_in(vec![gpr])
+                .emit(
+                    r#"
+                        let sp = StackRef::sp(stack_slot, &func.stack_slots);
+                        let base = stk_base(sp.base);
+                        {{PUT_OP}}(bits, rex2(base, in_reg0), sink);
+                        modrm_sib_disp32(in_reg0, sink);
+                        sib_noindex(base, sink);
+                        let imm : i32 = offset.into();
+                        sink.put4(sp.offset.checked_add(imm).unwrap() as u32);
+                    "#,
+                ),
+            regs
+        )
     );
 
     // Store recipes.

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -258,7 +258,7 @@ impl<'builder> Template<'builder> {
     pub fn nonrex(&self) -> Self {
         assert!(
             self.rex_kind != RexRecipeKind::AlwaysEmitRex,
-            "Template requires REX prefix."
+            "Template {} requires REX prefix.", self.name(),
         );
         let mut copy = self.clone();
         copy.rex_kind = RexRecipeKind::NeverEmitRex;
@@ -267,7 +267,7 @@ impl<'builder> Template<'builder> {
     pub fn rex(&self) -> Self {
         assert!(
             self.rex_kind != RexRecipeKind::NeverEmitRex,
-            "Template requires no REX prefix."
+            "Template {} requires no REX prefix.", self.name(),
         );
         if let Some(prefixed) = &self.when_prefixed {
             let mut ret = prefixed.rex();
@@ -284,7 +284,11 @@ impl<'builder> Template<'builder> {
     pub fn infer_rex(&self) -> Self {
         assert!(
             self.rex_kind != RexRecipeKind::NeverEmitRex,
-            "Template requires no REX prefix."
+            "Template {} requires no REX prefix.", self.name(),
+        );
+        assert!(
+            self.rex_kind != RexRecipeKind::AlwaysEmitRex,
+            "Template {} akways requires REX prefix.", self.name(),
         );
         assert!(
             self.when_prefixed.is_none(),

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -258,7 +258,8 @@ impl<'builder> Template<'builder> {
     pub fn nonrex(&self) -> Self {
         assert!(
             self.rex_kind != RexRecipeKind::AlwaysEmitRex,
-            "Template {} requires REX prefix.", self.name(),
+            "Template {} requires REX prefix.",
+            self.name(),
         );
         let mut copy = self.clone();
         copy.rex_kind = RexRecipeKind::NeverEmitRex;
@@ -267,7 +268,8 @@ impl<'builder> Template<'builder> {
     pub fn rex(&self) -> Self {
         assert!(
             self.rex_kind != RexRecipeKind::NeverEmitRex,
-            "Template {} requires no REX prefix.", self.name(),
+            "Template {} requires no REX prefix.",
+            self.name(),
         );
         if let Some(prefixed) = &self.when_prefixed {
             let mut ret = prefixed.rex();
@@ -284,11 +286,13 @@ impl<'builder> Template<'builder> {
     pub fn infer_rex(&self) -> Self {
         assert!(
             self.rex_kind != RexRecipeKind::NeverEmitRex,
-            "Template {} requires no REX prefix.", self.name(),
+            "Template {} requires no REX prefix.",
+            self.name(),
         );
         assert!(
             self.rex_kind != RexRecipeKind::AlwaysEmitRex,
-            "Template {} akways requires REX prefix.", self.name(),
+            "Template {} akways requires REX prefix.",
+            self.name(),
         );
         assert!(
             self.when_prefixed.is_none(),
@@ -1396,12 +1400,11 @@ pub(crate) fn define<'shared>(
     //
     // TODO Alternative forms for 8-bit immediates, when applicable.
 
-    recipes.add_template(
-        Template::new(
-            EncodingRecipeBuilder::new("spaddr_ld_id", &formats.stack_load, 6)
-                .operands_out(vec![gpr])
-                .emit(
-                    r#"
+    recipes.add_template(Template::new(
+        EncodingRecipeBuilder::new("spaddr_ld_id", &formats.stack_load, 6)
+            .operands_out(vec![gpr])
+            .emit(
+                r#"
                         let sp = StackRef::sp(stack_slot, &func.stack_slots);
                         let base = stk_base(sp.base);
                         {{PUT_OP}}(bits, rex2(base, out_reg0), sink);
@@ -1410,17 +1413,15 @@ pub(crate) fn define<'shared>(
                         let imm : i32 = offset.into();
                         sink.put4(sp.offset.checked_add(imm).unwrap() as u32);
                     "#,
-                ),
-            regs
-        )
-    );
+            ),
+        regs,
+    ));
 
-    recipes.add_template(
-        Template::new(
-            EncodingRecipeBuilder::new("spst_id", &formats.stack_store, 6)
-                .operands_in(vec![gpr])
-                .emit(
-                    r#"
+    recipes.add_template(Template::new(
+        EncodingRecipeBuilder::new("spst_id", &formats.stack_store, 6)
+            .operands_in(vec![gpr])
+            .emit(
+                r#"
                         let sp = StackRef::sp(stack_slot, &func.stack_slots);
                         let base = stk_base(sp.base);
                         {{PUT_OP}}(bits, rex2(base, in_reg0), sink);
@@ -1429,10 +1430,9 @@ pub(crate) fn define<'shared>(
                         let imm : i32 = offset.into();
                         sink.put4(sp.offset.checked_add(imm).unwrap() as u32);
                     "#,
-                ),
-            regs
-        )
-    );
+            ),
+        regs,
+    ));
 
     // Store recipes.
 

--- a/cranelift-filetests/src/test_binemit.rs
+++ b/cranelift-filetests/src/test_binemit.rs
@@ -140,7 +140,10 @@ impl SubTest for TestBinEmit {
         let min_offset = func
             .stack_slots
             .values()
-            .map(|slot| slot.offset.unwrap())
+            .map(|slot| {
+                slot.offset
+                    .expect("stack slots must have explicit offset for binemit tests")
+            })
             .min();
         func.stack_slots.layout_info = min_offset.map(|off| ir::StackLayoutInfo {
             frame_size: (-off) as u32,

--- a/filetests/isa/x86/stack-load-store64.clif
+++ b/filetests/isa/x86/stack-load-store64.clif
@@ -1,21 +1,14 @@
 ; legalization of stack load and store instructions on x86-64.
-test legalizer
+test binemit
 set opt_level=none
 target x86_64 haswell
 
 function %stack_load_and_store() {
-           ss0 = explicit_slot 8, offset 0
+           ss0 = explicit_slot 8, offset -8
+           ss1 = explicit_slot 8, offset -32
 
 block0:
-   v0 = stack_load.i64 ss0
-
-; check: v1 = stack_addr.i64 ss0
-; check: v0 = load.i64 notrap aligned v1
-
-   stack_store.i64 v0, ss0
-
-; check: v2 = stack_addr.i64 ss0
-; check: store notrap aligned v0, v2
-
-   return
+[RexOp1spaddr_ld_id#808b, %rax] v0 = stack_load.i64 ss0 ; bin: 48 8b 84 24 00000018
+[RexOp1spst_id#8089]            stack_store.i64 v0, ss0 ; bin: stk_ovf 48 89 84 24 00000018
+[Op1ret#c3]                     return
 }


### PR DESCRIPTION
- [x] This has been discussed in issue #597, or if not, please tell us why
  here.
- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
  This adds a `stack_load` and `stack_store` encoding for 32bit and 64bit integers. This saves one `lea` instruction for each `stack_load` and `stack_store`.
- [x] This PR contains test cases, if meaningful.
- [x] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.

<strike>
This currently doesn't encode `stack_load` and `stack_store` correctly.

```
[RexOp1spst_id#8089]                stack_store v0, ss1
[...]
@0000 [RexOp1spaddr_ld_id#808b,%rax] v20 = stack_load.i64 ss1
```

results in

```
  4a3df4:       48 89 bc 24 40 00 00    mov    %rdi,0x40(%rsp)
  4a3dfb:       00
[...]
  4a3e04:       48 8b 84 24 40 00 00    mov    0x40(%rsp),%rax
  4a3e0b:       00
```
</strike>