### PR TITLE
Improve support for reference-types

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/cpu_modes.rs
+++ b/cranelift-codegen/meta/src/cdsl/cpu_modes.rs
@@ -37,6 +37,12 @@ impl CpuMode {
         assert!(self.default_legalize.is_none());
         self.default_legalize = Some(group.id);
     }
+    pub fn legalize_value_type(&mut self, lane_type: impl Into<ValueType>, group: &TransformGroup) {
+        assert!(self
+            .typed_legalize
+            .insert(lane_type.into(), group.id)
+            .is_none());
+    }
     pub fn legalize_type(&mut self, lane_type: impl Into<LaneType>, group: &TransformGroup) {
         assert!(self
             .typed_legalize

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -239,6 +239,22 @@ impl PerCpuModeEncodings {
         self.enc64(inst.bind(R64), template.rex().w());
     }
 
+    fn enc_r32_r64_ld_st(&mut self, inst: &Instruction, w_bit: bool, template: Template) {
+        self.enc32(inst.clone().bind(R32).bind(Any), template.clone());
+
+        // REX-less encoding must come after REX encoding so we don't use it by
+        // default. Otherwise reg-alloc would never use r8 and up.
+        self.enc64(inst.clone().bind(R32).bind(Any), template.clone().rex());
+        self.enc64(inst.clone().bind(R32).bind(Any), template.clone());
+
+        if w_bit {
+            self.enc64(inst.clone().bind(R64).bind(Any), template.rex().w());
+        } else {
+            self.enc64(inst.clone().bind(R64).bind(Any), template.clone().rex());
+            self.enc64(inst.clone().bind(R64).bind(Any), template);
+        }
+    }
+
     /// Add encodings for `inst` to X86_64 with and without a REX prefix.
     fn enc_x86_64(&mut self, inst: impl Into<InstSpec> + Clone, template: Template) {
         // See above comment about the ordering of rex vs non-rex encodings.
@@ -858,6 +874,7 @@ fn define_memory(
 
     for recipe in &[rec_st, rec_stDisp8, rec_stDisp32] {
         e.enc_i32_i64_ld_st(store, true, recipe.opcodes(&MOV_STORE));
+        e.enc_r32_r64_ld_st(store, true, recipe.opcodes(&MOV_STORE));
         e.enc_x86_64(istore32.bind(I64).bind(Any), recipe.opcodes(&MOV_STORE));
         e.enc_i32_i64_ld_st(istore16, false, recipe.opcodes(&MOV_STORE_16));
     }
@@ -889,6 +906,7 @@ fn define_memory(
 
     for recipe in &[rec_ld, rec_ldDisp8, rec_ldDisp32] {
         e.enc_i32_i64_ld_st(load, true, recipe.opcodes(&MOV_LOAD));
+        e.enc_r32_r64_ld_st(load, true, recipe.opcodes(&MOV_LOAD));
         e.enc_x86_64(uload32.bind(I64), recipe.opcodes(&MOV_LOAD));
         e.enc64(sload32.bind(I64), recipe.opcodes(&MOVSXD).rex().w());
         e.enc_i32_i64_ld_st(uload16, true, recipe.opcodes(&MOVZX_WORD));

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -2329,10 +2329,12 @@ fn define_reftypes(e: &mut PerCpuModeEncodings, shared_defs: &SharedDefinitions,
     let shared = &shared_defs.instructions;
 
     let is_null = shared.by_name("is_null");
+    let is_invalid = shared.by_name("is_invalid");
     let null = shared.by_name("null");
     let safepoint = shared.by_name("safepoint");
 
     let rec_is_zero = r.template("is_zero");
+    let rec_is_invalid = r.template("is_invalid");
     let rec_pu_id_ref = r.template("pu_id_ref");
     let rec_safepoint = r.recipe("safepoint");
 
@@ -2344,6 +2346,9 @@ fn define_reftypes(e: &mut PerCpuModeEncodings, shared_defs: &SharedDefinitions,
 
     // is_null, implemented by testing whether the value is 0.
     e.enc_r32_r64_rex_only(is_null, rec_is_zero.opcodes(&TEST_REG));
+
+    // is_invalid, implemented by testing whether the value is -1.
+    e.enc_r32_r64_rex_only(is_invalid, rec_is_invalid.opcodes(&CMP_IMM8).rrr(7));
 
     // safepoint instruction calls sink, no actual encoding.
     e.enc32_rec(safepoint, rec_safepoint, 0);

--- a/cranelift-codegen/meta/src/isa/x86/mod.rs
+++ b/cranelift-codegen/meta/src/isa/x86/mod.rs
@@ -1,9 +1,11 @@
 use crate::cdsl::cpu_modes::CpuMode;
 use crate::cdsl::isa::TargetIsa;
+use crate::cdsl::types::ReferenceType;
 
 use crate::shared::types::Bool::B1;
 use crate::shared::types::Float::{F32, F64};
 use crate::shared::types::Int::{I16, I32, I64, I8};
+use crate::shared::types::Reference::{R32, R64};
 use crate::shared::Definitions as SharedDefinitions;
 
 mod encodings;
@@ -41,6 +43,7 @@ pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     x86_32.legalize_type(I8, widen);
     x86_32.legalize_type(I16, widen);
     x86_32.legalize_type(I32, x86_expand);
+    x86_32.legalize_value_type(ReferenceType(R32), x86_expand);
     x86_32.legalize_type(F32, x86_expand);
     x86_32.legalize_type(F64, x86_expand);
 
@@ -51,6 +54,7 @@ pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     x86_64.legalize_type(I16, widen);
     x86_64.legalize_type(I32, x86_expand);
     x86_64.legalize_type(I64, x86_expand);
+    x86_64.legalize_value_type(ReferenceType(R64), x86_expand);
     x86_64.legalize_type(F32, x86_expand);
     x86_64.legalize_type(F64, x86_expand);
 

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -3222,6 +3222,26 @@ pub(crate) fn define<'shared>(
             ),
     );
 
+    recipes.add_template_recipe(
+        EncodingRecipeBuilder::new("is_invalid", &formats.unary, 2 + 3)
+            .operands_in(vec![gpr])
+            .operands_out(vec![abcd])
+            .emit(
+                r#"
+                    // Comparison instruction.
+                    {{PUT_OP}}(bits, rex1(in_reg0), sink);
+                    modrm_r_bits(in_reg0, bits, sink);
+                    sink.put1(0xff);
+                    // `setCC` instruction, no REX.
+                    use crate::ir::condcodes::IntCC::*;
+                    let setcc = 0x90 | icc2opc(Equal);
+                    sink.put1(0x0f);
+                    sink.put1(setcc as u8);
+                    modrm_rr(out_reg0, 0, sink);
+                "#,
+            ),
+    );
+
     recipes.add_recipe(
         EncodingRecipeBuilder::new("safepoint", &formats.multiary, 0).emit(
             r#"

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -580,6 +580,7 @@ pub(crate) fn define(
             .ints(Interval::All)
             .floats(Interval::All)
             .simd_lanes(Interval::All)
+            .refs(Interval::All)
             .build(),
     );
 

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -3190,6 +3190,24 @@ pub(crate) fn define(
         .operands_out(vec![a]),
     );
 
+    let a = &Operand::new("a", b1);
+    let x = &Operand::new("x", Ref);
+
+    ig.push(
+        Inst::new(
+            "is_invalid",
+            r#"
+        Reference verification.
+
+        The condition code determines if the reference type in question is
+        invalid or not.
+        "#,
+            &formats.unary,
+        )
+        .operands_in(vec![x])
+        .operands_out(vec![a]),
+    );
+
     let Cond = &Operand::new("Cond", &imm.intcc);
     let f = &Operand::new("f", iflags);
     let a = &Operand::new("a", b1);

--- a/cranelift-codegen/src/binemit/stackmap.rs
+++ b/cranelift-codegen/src/binemit/stackmap.rs
@@ -6,10 +6,19 @@ use alloc::vec::Vec;
 type Num = u32;
 const NUM_BITS: usize = core::mem::size_of::<Num>() * 8;
 
-/// Wrapper class for longer bit vectors that cannot be represented by a single BitSet.
+/// A stack map is a bitmap with one bit per machine word on the stack. Stack
+/// maps are created at `safepoint` instructions and record all live reference
+/// values that are on the stack. All slot kinds, except `OutgoingArg` are
+/// captured in a stack map. The `OutgoingArg`'s will be captured in the callee
+/// function as `IncomingArg`'s.
+///
+/// The first value in the bitmap is of the lowest addressed slot on the stack.
+/// As all stacks in Isa's supported by Cranelift grow down, this means that
+/// first value is of the top of the stack and values proceed down the stack.
 #[derive(Clone, Debug)]
 pub struct Stackmap {
     bitmap: Vec<BitSet<Num>>,
+    mapped_words: u32,
 }
 
 impl Stackmap {
@@ -27,32 +36,37 @@ impl Stackmap {
         for val in args {
             if let Some(value_loc) = loc.get(*val) {
                 match *value_loc {
-                    ir::ValueLoc::Stack(stack_slot) => live_ref_in_stack_slot.insert(stack_slot),
-                    _ => false,
-                };
+                    ir::ValueLoc::Stack(stack_slot) => {
+                        live_ref_in_stack_slot.insert(stack_slot);
+                    }
+                    _ => {}
+                }
             }
         }
 
-        // SpiderMonkey stackmap structure:
-        // <trap reg dump> + <general spill> + <frame> + <inbound args>
-        // Bit vector goes from lower addresses to higher addresses.
-
-        // TODO: Get trap register layout from Spidermonkey and prepend to bitvector below.
         let stack = &func.stack_slots;
-        let frame_size = stack.frame_size.unwrap();
-        let word_size = ir::stackslot::StackSize::from(isa.pointer_bytes());
-        let num_words = (frame_size / word_size) as usize;
-        let mut vec = alloc::vec::Vec::with_capacity(num_words);
+        let info = func.stack_slots.layout_info.unwrap();
 
+        // Refer to the doc comment for `Stackmap` above to understand the
+        // bitmap representation used here.
+        let map_size = (info.frame_size + info.inbound_args_size) as usize;
+        let word_size = isa.pointer_bytes() as usize;
+        let num_words = map_size / word_size;
+
+        let mut vec = alloc::vec::Vec::with_capacity(num_words);
         vec.resize(num_words, false);
 
-        // Frame (includes spills and inbound args).
         for (ss, ssd) in stack.iter() {
-            if live_ref_in_stack_slot.contains(&ss) {
-                // Assumption: greater magnitude of offset imply higher address.
-                let index = (((ssd.offset.unwrap().abs() as u32) - ssd.size) / word_size) as usize;
-                vec[index] = true;
+            if !live_ref_in_stack_slot.contains(&ss)
+                || ssd.kind == ir::stackslot::StackSlotKind::OutgoingArg
+            {
+                continue;
             }
+
+            debug_assert!(ssd.size as usize == word_size);
+            let bytes_from_bottom = info.frame_size as i32 + ssd.offset.unwrap();
+            let words_from_bottom = (bytes_from_bottom as usize) / word_size;
+            vec[words_from_bottom] = true;
         }
 
         Self::from_slice(&vec)
@@ -73,7 +87,10 @@ impl Stackmap {
             }
             bitmap.push(BitSet(curr_word));
         }
-        Self { bitmap }
+        Self {
+            mapped_words: len as u32,
+            bitmap,
+        }
     }
 
     /// Returns a specified bit.
@@ -82,6 +99,16 @@ impl Stackmap {
         let word_index = bit_index / NUM_BITS;
         let word_offset = (bit_index % NUM_BITS) as u8;
         self.bitmap[word_index].contains(word_offset)
+    }
+
+    /// Returns the raw bitmap that represents this stack map.
+    pub fn as_slice(&self) -> &[BitSet<u32>] {
+        &self.bitmap
+    }
+
+    /// Returns the number of words represented by this stack map.
+    pub fn mapped_words(&self) -> u32 {
+        self.mapped_words
     }
 }
 

--- a/cranelift-codegen/src/ir/mod.rs
+++ b/cranelift-codegen/src/ir/mod.rs
@@ -53,7 +53,7 @@ pub use crate::ir::libcall::{get_libcall_funcref, get_probestack_funcref, LibCal
 pub use crate::ir::memflags::MemFlags;
 pub use crate::ir::progpoint::{ExpandedProgramPoint, ProgramOrder, ProgramPoint};
 pub use crate::ir::sourceloc::SourceLoc;
-pub use crate::ir::stackslot::{StackSlotData, StackSlotKind, StackSlots};
+pub use crate::ir::stackslot::{StackLayoutInfo, StackSlotData, StackSlotKind, StackSlots};
 pub use crate::ir::table::TableData;
 pub use crate::ir::trapcode::TrapCode;
 pub use crate::ir::types::Type;

--- a/cranelift-codegen/src/ir/stackslot.rs
+++ b/cranelift-codegen/src/ir/stackslot.rs
@@ -162,6 +162,23 @@ impl fmt::Display for StackSlotData {
     }
 }
 
+/// Stack frame layout information.
+///
+/// This is computed by the `layout_stack()` method.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+pub struct StackLayoutInfo {
+    /// The total size of the stack frame.
+    ///
+    /// This is the distance from the stack pointer in the current function to the stack pointer in
+    /// the calling function, so it includes a pushed return address as well as space for outgoing
+    /// call arguments.
+    pub frame_size: StackSize,
+
+    /// The total size of the stack frame for inbound arguments pushed by the caller.
+    pub inbound_args_size: StackSize,
+}
+
 /// Stack frame manager.
 ///
 /// Keep track of all the stack slots used by a function.
@@ -177,14 +194,8 @@ pub struct StackSlots {
     /// All the emergency slots.
     emergency: Vec<StackSlot>,
 
-    /// The total size of the stack frame.
-    ///
-    /// This is the distance from the stack pointer in the current function to the stack pointer in
-    /// the calling function, so it includes a pushed return address as well as space for outgoing
-    /// call arguments.
-    ///
-    /// This is computed by the `layout()` method.
-    pub frame_size: Option<StackSize>,
+    /// Layout information computed from `layout_stack`.
+    pub layout_info: Option<StackLayoutInfo>,
 }
 
 /// Stack slot manager functions that behave mostly like an entity map.
@@ -195,7 +206,7 @@ impl StackSlots {
             slots: PrimaryMap::new(),
             outgoing: Vec::new(),
             emergency: Vec::new(),
-            frame_size: None,
+            layout_info: None,
         }
     }
 
@@ -204,7 +215,7 @@ impl StackSlots {
         self.slots.clear();
         self.outgoing.clear();
         self.emergency.clear();
-        self.frame_size = None;
+        self.layout_info = None;
     }
 
     /// Allocate a new stack slot.

--- a/cranelift-codegen/src/isa/stack.rs
+++ b/cranelift-codegen/src/isa/stack.rs
@@ -36,8 +36,9 @@ impl StackRef {
     /// Get a reference to `ss` using the stack pointer as a base.
     pub fn sp(ss: StackSlot, frame: &StackSlots) -> Self {
         let size = frame
-            .frame_size
-            .expect("Stack layout must be computed before referencing stack slots");
+            .layout_info
+            .expect("Stack layout must be computed before referencing stack slots")
+            .frame_size;
         let slot = &frame[ss];
         let offset = if slot.kind == StackSlotKind::OutgoingArg {
             // Outgoing argument slots have offsets relative to our stack pointer.

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -333,7 +333,7 @@ pub fn legalize_signature(
 
 /// Get register class for a type appearing in a legalized signature.
 pub fn regclass_for_abi_type(ty: ir::Type) -> RegClass {
-    if ty.is_int() || ty.is_bool() {
+    if ty.is_int() || ty.is_bool() || ty.is_ref() {
         GPR
     } else {
         FPR

--- a/cranelift-filetests/src/test_binemit.rs
+++ b/cranelift-filetests/src/test_binemit.rs
@@ -142,7 +142,10 @@ impl SubTest for TestBinEmit {
             .values()
             .map(|slot| slot.offset.unwrap())
             .min();
-        func.stack_slots.frame_size = min_offset.map(|off| (-off) as u32);
+        func.stack_slots.layout_info = min_offset.map(|off| ir::StackLayoutInfo {
+            frame_size: (-off) as u32,
+            inbound_args_size: 0,
+        });
 
         let opt_level = isa.flags().opt_level();
 

--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -1151,7 +1151,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             segment,
             table: table_index,
         } => {
-            // The WebAssembly MVP only supports one table and we assume it here.
             let table = state.get_table(builder.func, *table_index, environ)?;
             let len = state.pop1();
             let src = state.pop1();

--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -975,7 +975,8 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         Operator::RefIsNull => {
             let arg = state.pop1();
             let val = builder.ins().is_null(arg);
-            state.push1(val);
+            let val_int = builder.ins().bint(I32, val);
+            state.push1(val_int);
         }
         Operator::RefFunc { function_index } => {
             state.push1(environ.translate_ref_func(builder.cursor(), *function_index)?);

--- a/cranelift-wasm/src/environ/dummy.rs
+++ b/cranelift-wasm/src/environ/dummy.rs
@@ -426,6 +426,35 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         Ok(pos.ins().iconst(I32, -1))
     }
 
+    fn translate_table_grow(
+        &mut self,
+        mut pos: FuncCursor,
+        _table_index: u32,
+        _delta: ir::Value,
+        _init_value: ir::Value,
+    ) -> WasmResult<ir::Value> {
+        Ok(pos.ins().iconst(I32, -1))
+    }
+
+    fn translate_table_get(
+        &mut self,
+        mut pos: FuncCursor,
+        _table_index: u32,
+        _index: ir::Value,
+    ) -> WasmResult<ir::Value> {
+        Ok(pos.ins().null(self.reference_type()))
+    }
+
+    fn translate_table_set(
+        &mut self,
+        _pos: FuncCursor,
+        _table_index: u32,
+        _value: ir::Value,
+        _index: ir::Value,
+    ) -> WasmResult<()> {
+        Ok(())
+    }
+
     fn translate_table_copy(
         &mut self,
         _pos: FuncCursor,
@@ -435,6 +464,17 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         _src_table: ir::Table,
         _dst: ir::Value,
         _src: ir::Value,
+        _len: ir::Value,
+    ) -> WasmResult<()> {
+        Ok(())
+    }
+
+    fn translate_table_fill(
+        &mut self,
+        _pos: FuncCursor,
+        _table_index: u32,
+        _dst: ir::Value,
+        _val: ir::Value,
         _len: ir::Value,
     ) -> WasmResult<()> {
         Ok(())
@@ -455,6 +495,14 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
 
     fn translate_elem_drop(&mut self, _pos: FuncCursor, _seg_index: u32) -> WasmResult<()> {
         Ok(())
+    }
+
+    fn translate_ref_func(
+        &mut self,
+        mut pos: FuncCursor,
+        _func_index: u32,
+    ) -> WasmResult<ir::Value> {
+        Ok(pos.ins().null(self.reference_type()))
     }
 }
 

--- a/cranelift-wasm/src/environ/dummy.rs
+++ b/cranelift-wasm/src/environ/dummy.rs
@@ -504,6 +504,23 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
     ) -> WasmResult<ir::Value> {
         Ok(pos.ins().null(self.reference_type()))
     }
+
+    fn translate_custom_global_get(
+        &mut self,
+        mut pos: FuncCursor,
+        _global_index: GlobalIndex,
+    ) -> WasmResult<ir::Value> {
+        Ok(pos.ins().iconst(I32, -1))
+    }
+
+    fn translate_custom_global_set(
+        &mut self,
+        _pos: FuncCursor,
+        _global_index: GlobalIndex,
+        _val: ir::Value,
+    ) -> WasmResult<()> {
+        Ok(())
+    }
 }
 
 impl TargetEnvironment for DummyEnvironment {

--- a/cranelift-wasm/src/environ/spec.rs
+++ b/cranelift-wasm/src/environ/spec.rs
@@ -36,6 +36,9 @@ pub enum GlobalVariable {
         /// The global variable's type.
         ty: ir::Type,
     },
+
+    /// This is a global variable that needs to be handled by the environment.
+    Custom,
 }
 
 /// A WebAssembly translation error.
@@ -405,6 +408,23 @@ pub trait FuncEnvironment: TargetEnvironment {
 
     /// Translate a `ref.func` WebAssembly instruction.
     fn translate_ref_func(&mut self, pos: FuncCursor, func_index: u32) -> WasmResult<ir::Value>;
+
+    /// Translate a `global.get` WebAssembly instruction at `pos` for a global
+    /// that is custom.
+    fn translate_custom_global_get(
+        &mut self,
+        pos: FuncCursor,
+        global_index: GlobalIndex,
+    ) -> WasmResult<ir::Value>;
+
+    /// Translate a `global.set` WebAssembly instruction at `pos` for a global
+    /// that is custom.
+    fn translate_custom_global_set(
+        &mut self,
+        pos: FuncCursor,
+        global_index: GlobalIndex,
+        val: ir::Value,
+    ) -> WasmResult<()>;
 
     /// Emit code at the beginning of every wasm loop.
     ///

--- a/cranelift-wasm/src/environ/spec.rs
+++ b/cranelift-wasm/src/environ/spec.rs
@@ -337,6 +337,32 @@ pub trait FuncEnvironment: TargetEnvironment {
         table: ir::Table,
     ) -> WasmResult<ir::Value>;
 
+    /// Translate a `table.grow` WebAssembly instruction.
+    fn translate_table_grow(
+        &mut self,
+        pos: FuncCursor,
+        table_index: u32,
+        delta: ir::Value,
+        init_value: ir::Value,
+    ) -> WasmResult<ir::Value>;
+
+    /// Translate a `table.get` WebAssembly instruction.
+    fn translate_table_get(
+        &mut self,
+        pos: FuncCursor,
+        table_index: u32,
+        index: ir::Value,
+    ) -> WasmResult<ir::Value>;
+
+    /// Translate a `table.set` WebAssembly instruction.
+    fn translate_table_set(
+        &mut self,
+        pos: FuncCursor,
+        table_index: u32,
+        value: ir::Value,
+        index: ir::Value,
+    ) -> WasmResult<()>;
+
     /// Translate a `table.copy` WebAssembly instruction.
     #[allow(clippy::too_many_arguments)]
     fn translate_table_copy(
@@ -348,6 +374,16 @@ pub trait FuncEnvironment: TargetEnvironment {
         src_table: ir::Table,
         dst: ir::Value,
         src: ir::Value,
+        len: ir::Value,
+    ) -> WasmResult<()>;
+
+    /// Translate a `table.fill` WebAssembly instruction.
+    fn translate_table_fill(
+        &mut self,
+        pos: FuncCursor,
+        table_index: u32,
+        dst: ir::Value,
+        val: ir::Value,
         len: ir::Value,
     ) -> WasmResult<()>;
 
@@ -366,6 +402,9 @@ pub trait FuncEnvironment: TargetEnvironment {
 
     /// Translate a `elem.drop` WebAssembly instruction.
     fn translate_elem_drop(&mut self, pos: FuncCursor, seg_index: u32) -> WasmResult<()>;
+
+    /// Translate a `ref.func` WebAssembly instruction.
+    fn translate_ref_func(&mut self, pos: FuncCursor, func_index: u32) -> WasmResult<ir::Value>;
 
     /// Emit code at the beginning of every wasm loop.
     ///

--- a/filetests/wasm/r32.clif
+++ b/filetests/wasm/r32.clif
@@ -1,0 +1,75 @@
+; Test basic code generation for 32-bit reftypes
+; This test is the 32-bit version of r64.clif. If you change this test you
+; should most likely update that test as well.
+test compile
+set enable_safepoints=true
+
+target i686 haswell
+
+function %select_ref(i32, r32, r32) -> r32 {
+ebb0(v0: i32, v1: r32, v2: r32):
+    brz v0, ebb1(v2)
+    jump ebb1(v1)
+
+ebb1(v3: r32):
+    return v3
+}
+
+function %table_set(i32, r32, i32 vmctx) {
+    gv0 = vmctx
+    gv1 = load.i32 notrap aligned gv0
+    gv2 = load.i32 notrap aligned gv0 +4
+    table0 = dynamic gv1, element_size 1, bound gv2, index_type i32
+
+ebb0(v0: i32, v1: r32, v2: i32):
+    v3 = table_addr.i32 table0, v0, +0;
+    store.r32 notrap aligned v1, v3
+    return
+}
+
+function %table_get(i32, i32 vmctx) -> r32 {
+    gv0 = vmctx
+    gv1 = load.i32 notrap aligned gv0
+    gv2 = load.i32 notrap aligned gv0 +4
+    table0 = dynamic gv1, element_size 1, bound gv2, index_type i32
+
+ebb0(v0: i32, v1: i32):
+    v2 = table_addr.i32 table0, v0, +0;
+    v3 = load.r32 notrap aligned v2
+    return v3
+}
+
+function %test_refs(r32, r32, r32, i32 vmctx) {
+    fn0 = %select_ref(i32, r32, r32) -> r32
+    fn1 = %table_set(i32, r32, i32 vmctx)
+    fn2 = %table_get(i32, i32 vmctx) -> r32
+
+ebb0(v0: r32, v1: r32, v2: r32, v3: i32):
+    v4 = iconst.i32 0
+    v5 = iconst.i32 1
+    v8 = iconst.i32 2
+
+    ; Shuffle around the first two refs
+    v6 = call fn0(v4, v0, v1)
+    v7 = call fn0(v5, v0, v1)
+
+    ; Store in the table
+    call fn1(v4, v6, v3)
+    call fn1(v5, v7, v3)
+    call fn1(v8, v2, v3)
+
+    ; Load from the table
+    v9 = call fn2(v4, v3)
+    v10 = call fn2(v5, v3)
+    v11 = call fn2(v8, v3)
+
+    ; Compare the results
+    v12 = is_null v9
+    trapnz v12, user0
+    v13 = is_null v10
+    trapnz v13, user0
+    v14 = is_invalid v11
+    trapnz v14, user0
+
+    return
+}

--- a/filetests/wasm/r64.clif
+++ b/filetests/wasm/r64.clif
@@ -1,0 +1,75 @@
+; Test basic code generation for 64-bit reftypes
+; This test is the 64-bit version of r32.clif. If you change this test you
+; should most likely update that test as well.
+test compile
+set enable_safepoints=true
+
+target x86_64 haswell
+
+function %select_ref(i32, r64, r64) -> r64 {
+ebb0(v0: i32, v1: r64, v2: r64):
+    brz v0, ebb1(v2)
+    jump ebb1(v1)
+
+ebb1(v3: r64):
+    return v3
+}
+
+function %table_set(i32, r64, i64 vmctx) {
+    gv0 = vmctx
+    gv1 = load.i64 notrap aligned gv0
+    gv2 = load.i32 notrap aligned gv0 +8
+    table0 = dynamic gv1, element_size 1, bound gv2, index_type i32
+
+ebb0(v0: i32, v1: r64, v2: i64):
+    v3 = table_addr.i64 table0, v0, +0;
+    store.r64 notrap aligned v1, v3
+    return
+}
+
+function %table_get(i32, i64 vmctx) -> r64 {
+    gv0 = vmctx
+    gv1 = load.i64 notrap aligned gv0
+    gv2 = load.i32 notrap aligned gv0 +8
+    table0 = dynamic gv1, element_size 1, bound gv2, index_type i32
+
+ebb0(v0: i32, v1: i64):
+    v2 = table_addr.i64 table0, v0, +0;
+    v3 = load.r64 notrap aligned v2
+    return v3
+}
+
+function %test_refs(r64, r64, r64, i64 vmctx) {
+    fn0 = %select_ref(i32, r64, r64) -> r64
+    fn1 = %table_set(i32, r64, i64 vmctx)
+    fn2 = %table_get(i32, i64 vmctx) -> r64
+
+ebb0(v0: r64, v1: r64, v2: r64, v3: i64):
+    v4 = iconst.i32 0
+    v5 = iconst.i32 1
+    v8 = iconst.i32 2
+
+    ; Shuffle around the first two refs
+    v6 = call fn0(v4, v0, v1)
+    v7 = call fn0(v5, v0, v1)
+
+    ; Store in the table
+    call fn1(v4, v6, v3)
+    call fn1(v5, v7, v3)
+    call fn1(v8, v2, v3)
+
+    ; Load from the table
+    v9 = call fn2(v4, v3)
+    v10 = call fn2(v5, v3)
+    v11 = call fn2(v8, v3)
+
+    ; Compare the results
+    v12 = is_null v9
+    trapnz v12, user0
+    v13 = is_null v10
+    trapnz v13, user0
+    v14 = is_invalid v11
+    trapnz v14, user0
+
+    return
+}


### PR DESCRIPTION
This is the Cranelift part of the work to add reference-types to Spidermonkey+Cranelift (see [bug 1574865](https://bugzilla.mozilla.org/show_bug.cgi?id=1574865)). I will post the Spidermonkey patches there soon.

I also have two additional commits that are blocked on bytecodealliance/wasmparser#168, but this is the majority of the work.