### PR TITLE
Refactor unwind; add FDE support.

### DIFF
--- a/cranelift-codegen/Cargo.toml
+++ b/cranelift-codegen/Cargo.toml
@@ -20,6 +20,7 @@ hashbrown = { version = "0.6", optional = true }
 target-lexicon = "0.10"
 log = { version = "0.4.6", default-features = false }
 serde = { version = "1.0.94", features = ["derive"], optional = true }
+gimli = { version = "0.19.0", optional = true }
 smallvec = { version = "1.0.0" }
 thiserror = "1.0.4"
 byteorder = { version = "1.3.2", default-features = false }
@@ -32,7 +33,7 @@ byteorder = { version = "1.3.2", default-features = false }
 cranelift-codegen-meta = { path = "meta", version = "0.54.0" }
 
 [features]
-default = ["std", "basic-blocks"]
+default = ["std", "basic-blocks", "unwind"]
 
 # The "std" feature enables use of libstd. The "core" feature enables use
 # of some minimal std-like replacement libraries. At least one of these two
@@ -46,6 +47,9 @@ core = ["hashbrown"]
 # This enables some additional functions useful for writing tests, but which
 # can significantly increase the size of the library.
 testing_hooks = []
+
+# This enables unwind info generation functionality.
+unwind = ["gimli"]
 
 # ISA targets for which we should build.
 # If no ISA targets are explicitly enabled, the ISA target for the host machine is enabled.

--- a/cranelift-codegen/Cargo.toml
+++ b/cranelift-codegen/Cargo.toml
@@ -20,7 +20,7 @@ hashbrown = { version = "0.6", optional = true }
 target-lexicon = "0.10"
 log = { version = "0.4.6", default-features = false }
 serde = { version = "1.0.94", features = ["derive"], optional = true }
-gimli = { version = "0.19.0", optional = true }
+gimli = { version = "0.19.0", default-features = false, features = ["write"], optional = true }
 smallvec = { version = "1.0.0" }
 thiserror = "1.0.4"
 byteorder = { version = "1.3.2", default-features = false }

--- a/cranelift-codegen/src/binemit/mod.rs
+++ b/cranelift-codegen/src/binemit/mod.rs
@@ -156,6 +156,7 @@ pub trait CodeSink {
 }
 
 /// Type of the frame unwind information.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum FrameUnwindKind {
     /// Windows fastcall unwinding (as in .pdata).
     Fastcall,

--- a/cranelift-codegen/src/binemit/mod.rs
+++ b/cranelift-codegen/src/binemit/mod.rs
@@ -163,19 +163,25 @@ pub enum FrameUnwindKind {
     Libunwind,
 }
 
+/// Offset in frame unwind information buffer.
+pub type FrameUnwindOffset = usize;
+
 /// Sink for frame unwind information.
 pub trait FrameUnwindSink {
     /// Get the current position.
-    fn offset(&self) -> CodeOffset;
+    fn len(&self) -> FrameUnwindOffset;
 
     /// Add bytes to the code section.
     fn bytes(&mut self, _: &[u8]);
 
+    /// Reserves bytes in the buffer.
+    fn reserve(&mut self, _len: usize) {}
+
     /// Add a relocation entry.
-    fn reloc(&mut self, _: Reloc, _: CodeOffset);
+    fn reloc(&mut self, _: Reloc, _: FrameUnwindOffset);
 
     /// Specified offset to main structure.
-    fn set_entry_offset(&mut self, _: CodeOffset);
+    fn set_entry_offset(&mut self, _: FrameUnwindOffset);
 }
 
 /// Report a bad encoding error.

--- a/cranelift-codegen/src/binemit/mod.rs
+++ b/cranelift-codegen/src/binemit/mod.rs
@@ -155,6 +155,29 @@ pub trait CodeSink {
     fn add_stackmap(&mut self, _: &[Value], _: &Function, _: &dyn TargetIsa);
 }
 
+/// Type of the frame unwind information.
+pub enum FrameUnwindKind {
+    /// Windows fastcall unwinding (as in .pdata).
+    Fastcall,
+    /// FDE entry for libunwind (similar to .eh_frame format).
+    Libunwind,
+}
+
+/// Sink for frame unwind information.
+pub trait FrameUnwindSink {
+    /// Get the current position.
+    fn offset(&self) -> CodeOffset;
+
+    /// Add bytes to the code section.
+    fn bytes(&mut self, _: &[u8]);
+
+    /// Add a relocation entry.
+    fn reloc(&mut self, _: Reloc, _: CodeOffset);
+
+    /// Specified offset to main structure.
+    fn set_entry_offset(&mut self, _: CodeOffset);
+}
+
 /// Report a bad encoding error.
 #[cold]
 pub fn bad_encoding(func: &Function, inst: Inst) -> ! {

--- a/cranelift-codegen/src/context.rs
+++ b/cranelift-codegen/src/context.rs
@@ -10,8 +10,8 @@
 //! single ISA instance.
 
 use crate::binemit::{
-    relax_branches, shrink_instructions, CodeInfo, MemoryCodeSink, RelocSink, StackmapSink,
-    TrapSink,
+    relax_branches, shrink_instructions, CodeInfo, FrameUnwindKind, FrameUnwindSink,
+    MemoryCodeSink, RelocSink, StackmapSink, TrapSink,
 };
 use crate::dce::do_dce;
 use crate::dominator_tree::DominatorTree;
@@ -201,8 +201,13 @@ impl Context {
     ///
     /// Only some calling conventions (e.g. Windows fastcall) will have unwind information.
     /// This is a no-op if the function has no unwind information.
-    pub fn emit_unwind_info(&self, isa: &dyn TargetIsa, mem: &mut Vec<u8>) {
-        isa.emit_unwind_info(&self.func, mem);
+    pub fn emit_unwind_info(
+        &self,
+        isa: &dyn TargetIsa,
+        kind: FrameUnwindKind,
+        sink: &mut dyn FrameUnwindSink,
+    ) {
+        isa.emit_unwind_info(&self.func, kind, sink);
     }
 
     /// Run the verifier on the function.

--- a/cranelift-codegen/src/ir/function.rs
+++ b/cranelift-codegen/src/ir/function.rs
@@ -253,6 +253,11 @@ impl Function {
     /// Starts collection of debug information.
     pub fn collect_debug_info(&mut self) {
         self.dfg.collect_debug_info();
+        self.collect_frame_layout_info();
+    }
+
+    /// Starts collection of frame layout information.
+    pub fn collect_frame_layout_info(&mut self) {
         self.frame_layout = Some(FrameLayout::new());
     }
 

--- a/cranelift-codegen/src/isa/mod.rs
+++ b/cranelift-codegen/src/isa/mod.rs
@@ -63,7 +63,6 @@ use crate::settings::SetResult;
 use crate::timing;
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
-use alloc::vec::Vec;
 use core::fmt;
 use target_lexicon::{triple, Architecture, PointerWidth, Triple};
 use thiserror::Error;
@@ -382,7 +381,12 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
     /// Emit unwind information for the given function.
     ///
     /// Only some calling conventions (e.g. Windows fastcall) will have unwind information.
-    fn emit_unwind_info(&self, _func: &ir::Function, _mem: &mut Vec<u8>) {
+    fn emit_unwind_info(
+        &self,
+        _func: &ir::Function,
+        _kind: binemit::FrameUnwindKind,
+        _sink: &mut dyn binemit::FrameUnwindSink,
+    ) {
         // No-op by default
     }
 }

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -1,11 +1,14 @@
 //! x86 ABI implementation.
 
 use super::super::settings as shared_settings;
+#[cfg(feature = "unwind")]
 use super::fde::emit_fde;
 use super::registers::{FPR, GPR, RU};
 use super::settings as isa_settings;
+#[cfg(feature = "unwind")]
 use super::unwind::UnwindInfo;
 use crate::abi::{legalize_args, ArgAction, ArgAssigner, ValueConversion};
+#[cfg(feature = "unwind")]
 use crate::binemit::{FrameUnwindKind, FrameUnwindSink};
 use crate::cursor::{Cursor, CursorPosition, EncCursor};
 use crate::ir;
@@ -948,6 +951,7 @@ fn insert_common_epilogue(
     }
 }
 
+#[cfg(feature = "unwind")]
 pub fn emit_unwind_info(
     func: &ir::Function,
     isa: &dyn TargetIsa,

--- a/cranelift-codegen/src/isa/x86/fde.rs
+++ b/cranelift-codegen/src/isa/x86/fde.rs
@@ -192,18 +192,19 @@ pub fn emit_fde(func: &Function, isa: &dyn TargetIsa, sink: &mut dyn FrameUnwind
     let mut changes = Vec::new();
     for ebb in ebbs {
         for (offset, inst, size) in func.inst_offsets(ebb, &encinfo) {
+            let address_offset = (offset + size) as usize;
+            assert!(last_offset <= address_offset);
             if let Some(cmds) = frame_layout.instructions.get(&inst) {
-                let address_offset = (offset + size) as usize;
-                assert!(last_offset < address_offset);
                 for cmd in cmds.iter() {
                     changes.push((address_offset, cmd.clone()));
                 }
-                last_offset = address_offset;
             }
+            last_offset = address_offset;
         }
     }
 
     let len = last_offset as u32;
+
     let word_size = isa.pointer_bytes() as i32;
 
     let encoding = Encoding {

--- a/cranelift-codegen/src/isa/x86/fde.rs
+++ b/cranelift-codegen/src/isa/x86/fde.rs
@@ -1,0 +1,242 @@
+//! Support for FDE data generation.
+
+use crate::binemit::{CodeOffset, Reloc};
+use crate::ir::{FrameLayoutChange, Function};
+use crate::isa::{CallConv, RegUnit, TargetIsa};
+use alloc::vec::Vec;
+use core::convert::TryInto;
+use gimli::write::{
+    Address, CallFrameInstruction, CommonInformationEntry, EhFrame, EndianVec,
+    FrameDescriptionEntry, FrameTable, Result, Writer,
+};
+use gimli::{Encoding, Format, LittleEndian, Register, X86_64};
+use std::ptr;
+
+#[cfg(not(feature = "std"))]
+use hashbrown::HashMap;
+#[cfg(feature = "std")]
+use std::collections::HashMap;
+
+pub type FDERelocEntry = (CodeOffset, Reloc);
+
+const FUNCTION_ENTRY_ADDRESS: Address = Address::Symbol {
+    symbol: 0,
+    addend: 0,
+};
+
+#[derive(Clone)]
+struct FDEWriter {
+    vec: EndianVec<LittleEndian>,
+    relocs: Vec<FDERelocEntry>,
+}
+
+impl FDEWriter {
+    fn new() -> Self {
+        Self {
+            vec: EndianVec::new(LittleEndian),
+            relocs: Vec::new(),
+        }
+    }
+    fn into_vec_and_relocs(self) -> (Vec<u8>, Vec<FDERelocEntry>) {
+        (self.vec.into_vec(), self.relocs)
+    }
+}
+
+impl Writer for FDEWriter {
+    type Endian = LittleEndian;
+    fn endian(&self) -> Self::Endian {
+        LittleEndian
+    }
+    fn len(&self) -> usize {
+        self.vec.len()
+    }
+    fn write(&mut self, bytes: &[u8]) -> Result<()> {
+        self.vec.write(bytes)
+    }
+    fn write_at(&mut self, offset: usize, bytes: &[u8]) -> Result<()> {
+        self.vec.write_at(offset, bytes)
+    }
+    fn write_address(&mut self, address: Address, size: u8) -> Result<()> {
+        match address {
+            Address::Constant(_) => self.vec.write_address(address, size),
+            Address::Symbol { .. } => {
+                assert_eq!(address, FUNCTION_ENTRY_ADDRESS);
+                let rt = match size {
+                    4 => Reloc::Abs4,
+                    8 => Reloc::Abs8,
+                    _ => {
+                        panic!("Unexpected address size at FDEWriter::write_address");
+                    }
+                };
+                self.relocs.push((self.vec.len().try_into().unwrap(), rt));
+                self.vec.write_udata(0, size)
+            }
+        }
+    }
+}
+
+fn map_reg(isa: &dyn TargetIsa, reg: RegUnit) -> Register {
+    static mut REG_X86_MAP: Option<HashMap<RegUnit, Register>> = None;
+    // FIXME lazy initialization?
+    unsafe {
+        if REG_X86_MAP.is_none() {
+            REG_X86_MAP = Some(HashMap::new());
+        }
+        if let Some(val) = REG_X86_MAP.as_mut().unwrap().get(&reg) {
+            return *val;
+        }
+        assert!(isa.name() == "x86");
+        let name = format!("{}", isa.register_info().display_regunit(reg));
+        let result = match name.as_str() {
+            "%rax" => X86_64::RAX,
+            "%rdx" => X86_64::RDX,
+            "%rcx" => X86_64::RCX,
+            "%rbx" => X86_64::RBX,
+            "%rsi" => X86_64::RSI,
+            "%rdi" => X86_64::RDI,
+            "%rbp" => X86_64::RBP,
+            "%rsp" => X86_64::RSP,
+            "%r8" => X86_64::R8,
+            "%r9" => X86_64::R9,
+            "%r10" => X86_64::R10,
+            "%r11" => X86_64::R11,
+            "%r12" => X86_64::R12,
+            "%r13" => X86_64::R13,
+            "%r14" => X86_64::R14,
+            "%r15" => X86_64::R15,
+            "%xmm0" => X86_64::XMM0,
+            "%xmm1" => X86_64::XMM1,
+            "%xmm2" => X86_64::XMM2,
+            "%xmm3" => X86_64::XMM3,
+            "%xmm4" => X86_64::XMM4,
+            "%xmm5" => X86_64::XMM5,
+            "%xmm6" => X86_64::XMM6,
+            "%xmm7" => X86_64::XMM7,
+            _ => panic!("{}", reg),
+        };
+        REG_X86_MAP.as_mut().unwrap().insert(reg, result);
+        result
+    }
+}
+
+fn to_cfi(
+    isa: &dyn TargetIsa,
+    change: &FrameLayoutChange,
+    cfa_def_reg: &mut Register,
+    cfa_def_offset: &mut i32,
+) -> Option<CallFrameInstruction> {
+    Some(match change {
+        FrameLayoutChange::CallFrameAddressAt { reg, offset } => {
+            let mapped = map_reg(isa, *reg);
+            let offset = (*offset) as i32;
+            if mapped != *cfa_def_reg && offset != *cfa_def_offset {
+                *cfa_def_reg = mapped;
+                *cfa_def_offset = offset;
+                CallFrameInstruction::Cfa(mapped, offset)
+            } else if offset != *cfa_def_offset {
+                *cfa_def_offset = offset;
+                CallFrameInstruction::CfaOffset(offset)
+            } else if mapped != *cfa_def_reg {
+                *cfa_def_reg = mapped;
+                CallFrameInstruction::CfaRegister(mapped)
+            } else {
+                return None;
+            }
+        }
+        FrameLayoutChange::RegAt { reg, cfa_offset } => {
+            assert!(cfa_offset % -8 == 0);
+            let cfa_offset = *cfa_offset as i32;
+            let mapped = map_reg(isa, *reg);
+            CallFrameInstruction::Offset(mapped, cfa_offset)
+        }
+        FrameLayoutChange::ReturnAddressAt { cfa_offset } => {
+            assert!(cfa_offset % -8 == 0);
+            let cfa_offset = *cfa_offset as i32;
+            CallFrameInstruction::Offset(X86_64::RA, cfa_offset)
+        }
+        _ => {
+            return None;
+        }
+    })
+}
+
+/// Creates FDE structure from FrameLayout.
+pub fn emit_fde(func: &Function, isa: &dyn TargetIsa) -> (Vec<u8>, usize, Vec<FDERelocEntry>) {
+    assert!(isa.name() == "x86");
+
+    // Expecting function with System V prologue
+    assert!(
+        func.signature.call_conv == CallConv::Fast
+            || func.signature.call_conv == CallConv::Cold
+            || func.signature.call_conv == CallConv::SystemV
+    );
+
+    assert!(func.frame_layout.is_some(), "expected func.frame_layout");
+    let frame_layout = func.frame_layout.as_ref().unwrap();
+
+    let mut ebbs = func.layout.ebbs().collect::<Vec<_>>();
+    ebbs.sort_by_key(|ebb| func.offsets[*ebb]); // Ensure inst offsets always increase
+
+    let encinfo = isa.encoding_info();
+    let mut last_offset = 0;
+    let mut changes = Vec::new();
+    for ebb in ebbs {
+        for (offset, inst, size) in func.inst_offsets(ebb, &encinfo) {
+            if let Some(cmds) = frame_layout.instructions.get(&inst) {
+                let address_offset = (offset + size) as usize;
+                assert!(last_offset < address_offset);
+                for cmd in cmds.iter() {
+                    changes.push((address_offset, cmd.clone()));
+                }
+                last_offset = address_offset;
+            }
+        }
+    }
+
+    let len = last_offset as u32;
+    let word_size = 8i32;
+
+    let encoding = Encoding {
+        format: Format::Dwarf32,
+        version: 1,
+        address_size: word_size as u8,
+    };
+    let mut frames = FrameTable::default();
+
+    let mut cfa_def_reg = X86_64::RA;
+    let mut cfa_def_offset = 0i32;
+
+    let mut cie = CommonInformationEntry::new(
+        encoding,
+        /* code_alignment_factor = */ 1,
+        /* data_alignment_factor = */ -word_size as i8,
+        /* return_address_register = */ X86_64::RA,
+    );
+    for ch in frame_layout.initial.iter() {
+        if let Some(cfi) = to_cfi(isa, ch, &mut cfa_def_reg, &mut cfa_def_offset) {
+            cie.add_instruction(cfi);
+        }
+    }
+
+    let cie_id = frames.add_cie(cie);
+
+    let mut fde = FrameDescriptionEntry::new(FUNCTION_ENTRY_ADDRESS, len);
+
+    for (addr, ch) in changes.iter() {
+        if let Some(cfi) = to_cfi(isa, ch, &mut cfa_def_reg, &mut cfa_def_offset) {
+            fde.add_instruction((*addr) as u32, cfi);
+        }
+    }
+
+    frames.add_fde(cie_id, fde);
+
+    let mut eh_frame = EhFrame::from(FDEWriter::new());
+    frames.write_eh_frame(&mut eh_frame).unwrap();
+
+    let (mut bytes, relocs) = eh_frame.clone().into_vec_and_relocs();
+    // Need 0 marker for GCC unwind to end FDE "list".
+    bytes.extend_from_slice(&[0, 0, 0, 0]);
+
+    let fde_offset = unsafe { ptr::read::<u32>(bytes.as_ptr() as *const u32) } as usize + 4;
+    (bytes, fde_offset, relocs)
+}

--- a/cranelift-codegen/src/isa/x86/mod.rs
+++ b/cranelift-codegen/src/isa/x86/mod.rs
@@ -3,6 +3,7 @@
 mod abi;
 mod binemit;
 mod enc_tables;
+mod fde;
 mod registers;
 pub mod settings;
 mod unwind;
@@ -11,6 +12,7 @@ use super::super::settings as shared_settings;
 #[cfg(feature = "testing_hooks")]
 use crate::binemit::CodeSink;
 use crate::binemit::{emit_function, MemoryCodeSink};
+use crate::binemit::{FrameUnwindKind, FrameUnwindSink};
 use crate::ir;
 use crate::isa::enc_tables::{self as shared_enc_tables, lookup_enclist, Encodings};
 use crate::isa::Builder as IsaBuilder;
@@ -20,7 +22,6 @@ use crate::result::CodegenResult;
 use crate::timing;
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
-use alloc::vec::Vec;
 use core::fmt;
 use target_lexicon::{PointerWidth, Triple};
 
@@ -157,8 +158,13 @@ impl TargetIsa for Isa {
     /// Emit unwind information for the given function.
     ///
     /// Only some calling conventions (e.g. Windows fastcall) will have unwind information.
-    fn emit_unwind_info(&self, func: &ir::Function, mem: &mut Vec<u8>) {
-        abi::emit_unwind_info(func, self, mem);
+    fn emit_unwind_info(
+        &self,
+        func: &ir::Function,
+        kind: FrameUnwindKind,
+        sink: &mut dyn FrameUnwindSink,
+    ) {
+        abi::emit_unwind_info(func, self, kind, sink);
     }
 }
 

--- a/cranelift-codegen/src/isa/x86/mod.rs
+++ b/cranelift-codegen/src/isa/x86/mod.rs
@@ -3,15 +3,18 @@
 mod abi;
 mod binemit;
 mod enc_tables;
+#[cfg(feature = "unwind")]
 mod fde;
 mod registers;
 pub mod settings;
+#[cfg(feature = "unwind")]
 mod unwind;
 
 use super::super::settings as shared_settings;
 #[cfg(feature = "testing_hooks")]
 use crate::binemit::CodeSink;
 use crate::binemit::{emit_function, MemoryCodeSink};
+#[cfg(feature = "unwind")]
 use crate::binemit::{FrameUnwindKind, FrameUnwindSink};
 use crate::ir;
 use crate::isa::enc_tables::{self as shared_enc_tables, lookup_enclist, Encodings};
@@ -158,6 +161,7 @@ impl TargetIsa for Isa {
     /// Emit unwind information for the given function.
     ///
     /// Only some calling conventions (e.g. Windows fastcall) will have unwind information.
+    #[cfg(feature = "unwind")]
     fn emit_unwind_info(
         &self,
         func: &ir::Function,

--- a/cranelift-filetests/Cargo.toml
+++ b/cranelift-filetests/Cargo.toml
@@ -16,6 +16,7 @@ cranelift-reader = { path = "../cranelift-reader", version = "0.54.0" }
 cranelift-preopt = { path = "../cranelift-preopt", version = "0.54.0" }
 file-per-thread-logger = "0.1.2"
 filecheck = "0.4.0"
+gimli = { version = "0.19.0", default-features = false, features = ["read"] }
 log = "0.4.6"
 memmap = "0.7.0"
 num_cpus = "1.8.0"

--- a/cranelift-filetests/src/lib.rs
+++ b/cranelift-filetests/src/lib.rs
@@ -42,6 +42,7 @@ mod test_cat;
 mod test_compile;
 mod test_dce;
 mod test_domtree;
+mod test_fde;
 mod test_legalizer;
 mod test_licm;
 mod test_postopt;
@@ -137,6 +138,7 @@ fn new_subtest(parsed: &TestCommand) -> subtest::SubtestResult<Box<dyn subtest::
         "preopt" => test_preopt::subtest(parsed),
         "safepoint" => test_safepoint::subtest(parsed),
         "unwind" => test_unwind::subtest(parsed),
+        "fde" => test_fde::subtest(parsed),
         _ => Err(format!("unknown test command '{}'", parsed.command)),
     }
 }

--- a/cranelift-filetests/src/test_fde.rs
+++ b/cranelift-filetests/src/test_fde.rs
@@ -1,0 +1,415 @@
+//! Test command for verifying the unwind emitted for each function.
+//!
+//! The `unwind` test command runs each function through the full code generator pipeline.
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
+
+use crate::subtest::{run_filecheck, Context, SubTest, SubtestResult};
+use cranelift_codegen;
+use cranelift_codegen::binemit::{FrameUnwindKind, FrameUnwindOffset, FrameUnwindSink, Reloc};
+use cranelift_codegen::ir;
+use cranelift_reader::TestCommand;
+use std::borrow::Cow;
+use std::fmt::Write;
+
+struct TestUnwind;
+
+pub fn subtest(parsed: &TestCommand) -> SubtestResult<Box<dyn SubTest>> {
+    assert_eq!(parsed.command, "fde");
+    if !parsed.options.is_empty() {
+        Err(format!("No options allowed on {}", parsed))
+    } else {
+        Ok(Box::new(TestUnwind))
+    }
+}
+
+impl SubTest for TestUnwind {
+    fn name(&self) -> &'static str {
+        "fde"
+    }
+
+    fn is_mutating(&self) -> bool {
+        false
+    }
+
+    fn needs_isa(&self) -> bool {
+        true
+    }
+
+    fn run(&self, func: Cow<ir::Function>, context: &Context) -> SubtestResult<()> {
+        let isa = context.isa.expect("unwind needs an ISA");
+
+        if func.signature.call_conv != cranelift_codegen::isa::CallConv::SystemV {
+            return run_filecheck(&"No unwind information.", context);
+        }
+
+        let mut comp_ctx = cranelift_codegen::Context::for_function(func.into_owned());
+        comp_ctx.func.collect_frame_layout_info();
+
+        comp_ctx.compile(isa).expect("failed to compile function");
+
+        struct SimpleUnwindSink(pub Vec<u8>, pub usize, pub Vec<(Reloc, usize)>);
+        impl FrameUnwindSink for SimpleUnwindSink {
+            fn len(&self) -> FrameUnwindOffset {
+                self.0.len()
+            }
+            fn bytes(&mut self, b: &[u8]) {
+                self.0.extend_from_slice(b);
+            }
+            fn reloc(&mut self, r: Reloc, off: FrameUnwindOffset) {
+                self.2.push((r, off));
+            }
+            fn set_entry_offset(&mut self, off: FrameUnwindOffset) {
+                self.1 = off;
+            }
+        }
+
+        let mut sink = SimpleUnwindSink(Vec::new(), 0, Vec::new());
+        comp_ctx.emit_unwind_info(isa, FrameUnwindKind::Libunwind, &mut sink);
+
+        let mut text = String::new();
+        if sink.0.is_empty() {
+            writeln!(text, "No unwind information.").unwrap();
+        } else {
+            print_unwind_info(&mut text, &sink.0, isa.pointer_bytes());
+            writeln!(text, "Entry: {}", sink.1).unwrap();
+            writeln!(text, "Relocs: {:?}", sink.2).unwrap();
+        }
+
+        run_filecheck(&text, context)
+    }
+}
+
+fn register_name<'a>(register: gimli::Register) -> std::borrow::Cow<'a, str> {
+    Cow::Owned(format!("r{}", register.0))
+}
+
+fn print_unwind_info(text: &mut String, mem: &[u8], address_size: u8) {
+    let mut eh_frame = gimli::EhFrame::new(mem, gimli::LittleEndian);
+    eh_frame.set_address_size(address_size);
+    let bases = gimli::BaseAddresses::default();
+    dwarfdump::dump_eh_frame(text, &eh_frame, &bases, &register_name).unwrap();
+}
+
+mod dwarfdump {
+    // Copied from https://github.com/gimli-rs/gimli/blob/1e49ffc9af4ec64a1b7316924d73c933dd7157c5/examples/dwarfdump.rs
+    use gimli::UnwindSection;
+    use std::borrow::Cow;
+    use std::collections::HashMap;
+    use std::fmt::{self, Debug, Write};
+    use std::result;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(super) enum Error {
+        GimliError(gimli::Error),
+        IoError,
+    }
+
+    impl fmt::Display for Error {
+        #[inline]
+        fn fmt(&self, f: &mut fmt::Formatter) -> ::std::result::Result<(), fmt::Error> {
+            Debug::fmt(self, f)
+        }
+    }
+
+    impl From<gimli::Error> for Error {
+        fn from(err: gimli::Error) -> Self {
+            Error::GimliError(err)
+        }
+    }
+
+    impl From<fmt::Error> for Error {
+        fn from(_: fmt::Error) -> Self {
+            Error::IoError
+        }
+    }
+
+    pub(super) type Result<T> = result::Result<T, Error>;
+
+    pub(super) trait Reader: gimli::Reader<Offset = usize> + Send + Sync {}
+
+    impl<'input, Endian> Reader for gimli::EndianSlice<'input, Endian> where
+        Endian: gimli::Endianity + Send + Sync
+    {
+    }
+
+    pub(super) fn dump_eh_frame<R: Reader, W: Write>(
+        w: &mut W,
+        eh_frame: &gimli::EhFrame<R>,
+        bases: &gimli::BaseAddresses,
+        register_name: &dyn Fn(gimli::Register) -> Cow<'static, str>,
+    ) -> Result<()> {
+        let mut cies = HashMap::new();
+
+        let mut entries = eh_frame.entries(bases);
+        loop {
+            match entries.next()? {
+                None => return Ok(()),
+                Some(gimli::CieOrFde::Cie(cie)) => {
+                    writeln!(w, "{:#010x}: CIE", cie.offset())?;
+                    writeln!(w, "        length: {:#010x}", cie.entry_len())?;
+                    // TODO: CIE_id
+                    writeln!(w, "       version: {:#04x}", cie.version())?;
+                    // TODO: augmentation
+                    writeln!(w, "    code_align: {}", cie.code_alignment_factor())?;
+                    writeln!(w, "    data_align: {}", cie.data_alignment_factor())?;
+                    writeln!(w, "   ra_register: {:#x}", cie.return_address_register().0)?;
+                    if let Some(encoding) = cie.lsda_encoding() {
+                        writeln!(w, " lsda_encoding: {:#02x}", encoding.0)?;
+                    }
+                    if let Some((encoding, personality)) = cie.personality_with_encoding() {
+                        write!(w, "   personality: {:#02x} ", encoding.0)?;
+                        dump_pointer(w, personality)?;
+                        writeln!(w)?;
+                    }
+                    if let Some(encoding) = cie.fde_address_encoding() {
+                        writeln!(w, "  fde_encoding: {:#02x}", encoding.0)?;
+                    }
+                    dump_cfi_instructions(
+                        w,
+                        cie.instructions(eh_frame, bases),
+                        true,
+                        register_name,
+                    )?;
+                    writeln!(w)?;
+                }
+                Some(gimli::CieOrFde::Fde(partial)) => {
+                    let mut offset = None;
+                    let fde = partial.parse(|_, bases, o| {
+                        offset = Some(o);
+                        cies.entry(o)
+                            .or_insert_with(|| eh_frame.cie_from_offset(bases, o))
+                            .clone()
+                    })?;
+
+                    writeln!(w)?;
+                    writeln!(w, "{:#010x}: FDE", fde.offset())?;
+                    writeln!(w, "        length: {:#010x}", fde.entry_len())?;
+                    writeln!(w, "   CIE_pointer: {:#010x}", offset.unwrap().0)?;
+                    // TODO: symbolicate the start address like the canonical dwarfdump does.
+                    writeln!(w, "    start_addr: {:#018x}", fde.initial_address())?;
+                    writeln!(
+                        w,
+                        "    range_size: {:#018x} (end_addr = {:#018x})",
+                        fde.len(),
+                        fde.initial_address() + fde.len()
+                    )?;
+                    if let Some(lsda) = fde.lsda() {
+                        write!(w, "          lsda: ")?;
+                        dump_pointer(w, lsda)?;
+                        writeln!(w)?;
+                    }
+                    dump_cfi_instructions(
+                        w,
+                        fde.instructions(eh_frame, bases),
+                        false,
+                        register_name,
+                    )?;
+                    writeln!(w)?;
+                }
+            }
+        }
+    }
+
+    fn dump_pointer<W: Write>(w: &mut W, p: gimli::Pointer) -> Result<()> {
+        match p {
+            gimli::Pointer::Direct(p) => {
+                write!(w, "{:#018x}", p)?;
+            }
+            gimli::Pointer::Indirect(p) => {
+                write!(w, "({:#018x})", p)?;
+            }
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::unneeded_field_pattern)]
+    fn dump_cfi_instructions<R: Reader, W: Write>(
+        w: &mut W,
+        mut insns: gimli::CallFrameInstructionIter<R>,
+        is_initial: bool,
+        register_name: &dyn Fn(gimli::Register) -> Cow<'static, str>,
+    ) -> Result<()> {
+        use gimli::CallFrameInstruction::*;
+
+        // TODO: we need to actually evaluate these instructions as we iterate them
+        // so we can print the initialized state for CIEs, and each unwind row's
+        // registers for FDEs.
+        //
+        // TODO: We should print DWARF expressions for the CFI instructions that
+        // embed DWARF expressions within themselves.
+
+        if !is_initial {
+            writeln!(w, "  Instructions:")?;
+        }
+
+        loop {
+            match insns.next() {
+                Err(e) => {
+                    writeln!(w, "Failed to decode CFI instruction: {}", e)?;
+                    return Ok(());
+                }
+                Ok(None) => {
+                    if is_initial {
+                        writeln!(w, "  Instructions: Init State:")?;
+                    }
+                    return Ok(());
+                }
+                Ok(Some(op)) => match op {
+                    SetLoc { address } => {
+                        writeln!(w, "                DW_CFA_set_loc ({:#x})", address)?;
+                    }
+                    AdvanceLoc { delta } => {
+                        writeln!(w, "                DW_CFA_advance_loc ({})", delta)?;
+                    }
+                    DefCfa { register, offset } => {
+                        writeln!(
+                            w,
+                            "                DW_CFA_def_cfa ({}, {})",
+                            register_name(register),
+                            offset
+                        )?;
+                    }
+                    DefCfaSf {
+                        register,
+                        factored_offset,
+                    } => {
+                        writeln!(
+                            w,
+                            "                DW_CFA_def_cfa_sf ({}, {})",
+                            register_name(register),
+                            factored_offset
+                        )?;
+                    }
+                    DefCfaRegister { register } => {
+                        writeln!(
+                            w,
+                            "                DW_CFA_def_cfa_register ({})",
+                            register_name(register)
+                        )?;
+                    }
+                    DefCfaOffset { offset } => {
+                        writeln!(w, "                DW_CFA_def_cfa_offset ({})", offset)?;
+                    }
+                    DefCfaOffsetSf { factored_offset } => {
+                        writeln!(
+                            w,
+                            "                DW_CFA_def_cfa_offset_sf ({})",
+                            factored_offset
+                        )?;
+                    }
+                    DefCfaExpression { expression: _ } => {
+                        writeln!(w, "                DW_CFA_def_cfa_expression (...)")?;
+                    }
+                    Undefined { register } => {
+                        writeln!(
+                            w,
+                            "                DW_CFA_undefined ({})",
+                            register_name(register)
+                        )?;
+                    }
+                    SameValue { register } => {
+                        writeln!(
+                            w,
+                            "                DW_CFA_same_value ({})",
+                            register_name(register)
+                        )?;
+                    }
+                    Offset {
+                        register,
+                        factored_offset,
+                    } => {
+                        writeln!(
+                            w,
+                            "                DW_CFA_offset ({}, {})",
+                            register_name(register),
+                            factored_offset
+                        )?;
+                    }
+                    OffsetExtendedSf {
+                        register,
+                        factored_offset,
+                    } => {
+                        writeln!(
+                            w,
+                            "                DW_CFA_offset_extended_sf ({}, {})",
+                            register_name(register),
+                            factored_offset
+                        )?;
+                    }
+                    ValOffset {
+                        register,
+                        factored_offset,
+                    } => {
+                        writeln!(
+                            w,
+                            "                DW_CFA_val_offset ({}, {})",
+                            register_name(register),
+                            factored_offset
+                        )?;
+                    }
+                    ValOffsetSf {
+                        register,
+                        factored_offset,
+                    } => {
+                        writeln!(
+                            w,
+                            "                DW_CFA_val_offset_sf ({}, {})",
+                            register_name(register),
+                            factored_offset
+                        )?;
+                    }
+                    Register {
+                        dest_register,
+                        src_register,
+                    } => {
+                        writeln!(
+                            w,
+                            "                DW_CFA_register ({}, {})",
+                            register_name(dest_register),
+                            register_name(src_register)
+                        )?;
+                    }
+                    Expression {
+                        register,
+                        expression: _,
+                    } => {
+                        writeln!(
+                            w,
+                            "                DW_CFA_expression ({}, ...)",
+                            register_name(register)
+                        )?;
+                    }
+                    ValExpression {
+                        register,
+                        expression: _,
+                    } => {
+                        writeln!(
+                            w,
+                            "                DW_CFA_val_expression ({}, ...)",
+                            register_name(register)
+                        )?;
+                    }
+                    Restore { register } => {
+                        writeln!(
+                            w,
+                            "                DW_CFA_restore ({})",
+                            register_name(register)
+                        )?;
+                    }
+                    RememberState => {
+                        writeln!(w, "                DW_CFA_remember_state")?;
+                    }
+                    RestoreState => {
+                        writeln!(w, "                DW_CFA_restore_state")?;
+                    }
+                    ArgsSize { size } => {
+                        writeln!(w, "                DW_CFA_GNU_args_size ({})", size)?;
+                    }
+                    Nop => {
+                        writeln!(w, "                DW_CFA_nop")?;
+                    }
+                },
+            }
+        }
+    }
+}

--- a/cranelift-filetests/src/test_unwind.rs
+++ b/cranelift-filetests/src/test_unwind.rs
@@ -6,7 +6,7 @@
 use crate::subtest::{run_filecheck, Context, SubTest, SubtestResult};
 use byteorder::{ByteOrder, LittleEndian};
 use cranelift_codegen;
-use cranelift_codegen::binemit::{CodeOffset, FrameUnwindKind, FrameUnwindSink, Reloc};
+use cranelift_codegen::binemit::{FrameUnwindKind, FrameUnwindOffset, FrameUnwindSink, Reloc};
 use cranelift_codegen::ir;
 use cranelift_reader::TestCommand;
 use std::borrow::Cow;
@@ -44,16 +44,16 @@ impl SubTest for TestUnwind {
 
         struct Sink(Vec<u8>);
         impl FrameUnwindSink for Sink {
-            fn offset(&self) -> CodeOffset {
-                self.0.len() as CodeOffset
+            fn len(&self) -> FrameUnwindOffset {
+                self.0.len()
             }
             fn bytes(&mut self, b: &[u8]) {
                 self.0.extend_from_slice(b);
             }
-            fn reloc(&mut self, _: Reloc, _: CodeOffset) {
+            fn reloc(&mut self, _: Reloc, _: FrameUnwindOffset) {
                 unimplemented!();
             }
-            fn set_entry_offset(&mut self, _: CodeOffset) {
+            fn set_entry_offset(&mut self, _: FrameUnwindOffset) {
                 unimplemented!();
             }
         }

--- a/cranelift-filetests/src/test_unwind.rs
+++ b/cranelift-filetests/src/test_unwind.rs
@@ -6,6 +6,7 @@
 use crate::subtest::{run_filecheck, Context, SubTest, SubtestResult};
 use byteorder::{ByteOrder, LittleEndian};
 use cranelift_codegen;
+use cranelift_codegen::binemit::{CodeOffset, FrameUnwindKind, FrameUnwindSink, Reloc};
 use cranelift_codegen::ir;
 use cranelift_reader::TestCommand;
 use std::borrow::Cow;
@@ -41,14 +42,30 @@ impl SubTest for TestUnwind {
 
         comp_ctx.compile(isa).expect("failed to compile function");
 
-        let mut mem = Vec::new();
-        comp_ctx.emit_unwind_info(isa, &mut mem);
+        struct Sink(Vec<u8>);
+        impl FrameUnwindSink for Sink {
+            fn offset(&self) -> CodeOffset {
+                self.0.len() as CodeOffset
+            }
+            fn bytes(&mut self, b: &[u8]) {
+                self.0.extend_from_slice(b);
+            }
+            fn reloc(&mut self, _: Reloc, _: CodeOffset) {
+                unimplemented!();
+            }
+            fn set_entry_offset(&mut self, _: CodeOffset) {
+                unimplemented!();
+            }
+        }
+
+        let mut sink = Sink(Vec::new());
+        comp_ctx.emit_unwind_info(isa, FrameUnwindKind::Fastcall, &mut sink);
 
         let mut text = String::new();
-        if mem.is_empty() {
+        if sink.0.is_empty() {
             writeln!(text, "No unwind information.").unwrap();
         } else {
-            print_unwind_info(&mut text, &mem);
+            print_unwind_info(&mut text, &sink.0);
         }
 
         run_filecheck(&text, context)

--- a/filetests/isa/x86/windows_systemv_x64_fde.clif
+++ b/filetests/isa/x86/windows_systemv_x64_fde.clif
@@ -1,0 +1,54 @@
+test fde
+set opt_level=speed_and_size
+set is_pic
+target x86_64 haswell
+
+; check that there is no libunwind information for a windows_fastcall function
+function %not_fastcall() windows_fastcall {
+ebb0:
+    return
+}
+; sameln: No unwind information.
+
+; check the libunwind information with a function with no args
+function %no_args() system_v {
+ebb0:
+    return
+}
+; sameln: 0x00000000: CIE
+; nextln:         length: 0x00000014
+; nextln:        version: 0x01
+; nextln:     code_align: 1
+; nextln:     data_align: -8
+; nextln:    ra_register: 0x10
+; nextln:                 DW_CFA_def_cfa (r7, 8)
+; nextln:                 DW_CFA_offset (r16, 1)
+; nextln:                 DW_CFA_nop
+; nextln:                 DW_CFA_nop
+; nextln:                 DW_CFA_nop
+; nextln:                 DW_CFA_nop
+; nextln:                 DW_CFA_nop
+; nextln:                 DW_CFA_nop
+; nextln:   Instructions: Init State:
+; nextln: 
+; nextln: 
+; nextln: 0x00000018: FDE
+; nextln:         length: 0x00000024
+; nextln:    CIE_pointer: 0x00000000
+; nextln:     start_addr: 0x0000000000000000
+; nextln:     range_size: 0x0000000000000006 (end_addr = 0x0000000000000006)
+; nextln:   Instructions:
+; nextln:                 DW_CFA_advance_loc (1)
+; nextln:                 DW_CFA_def_cfa_offset (16)
+; nextln:                 DW_CFA_offset (r6, 2)
+; nextln:                 DW_CFA_advance_loc (3)
+; nextln:                 DW_CFA_def_cfa_register (r6)
+; nextln:                 DW_CFA_advance_loc (1)
+; nextln:                 DW_CFA_def_cfa (r7, 8)
+; nextln:                 DW_CFA_nop
+; nextln:                 DW_CFA_nop
+; nextln:                 DW_CFA_nop
+; nextln:                 DW_CFA_nop
+; nextln: 
+; nextln: Entry: 24
+; nextln: Relocs: [(Abs8, 32)]


### PR DESCRIPTION
Currently, codegen produces unwind information only for Windows platform. We need to produce this type of information for all platforms to properly produce backtrace. See https://github.com/bytecodealliance/wasmtime/pull/759

TODO (and requires feedback):
- [x] use feature to cfg existing unwind logic
- [x] agree on location for FDE/UNWIND_INFO logic
- [x] borrow reg mapper from #902

cc @peterhuene @iximeow 