### PR TITLE
Renames Settings ⚠️  (fixes #976)

### DIFF
--- a/cranelift-codegen/meta/src/isa/x86/settings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/settings.rs
@@ -59,16 +59,16 @@ pub(crate) fn define(shared: &SettingGroup) -> SettingGroup {
     // back in the shared SettingGroup, and use it in x86 instruction predicates.
 
     let is_pic = shared.get_bool("is_pic");
-    let allones_funcaddrs = shared.get_bool("allones_funcaddrs");
+    let emit_all_ones_funcaddrs = shared.get_bool("emit_all_ones_funcaddrs");
     settings.add_predicate("is_pic", predicate!(is_pic));
     settings.add_predicate("not_is_pic", predicate!(!is_pic));
     settings.add_predicate(
         "all_ones_funcaddrs_and_not_is_pic",
-        predicate!(allones_funcaddrs && !is_pic),
+        predicate!(emit_all_ones_funcaddrs && !is_pic),
     );
     settings.add_predicate(
         "not_all_ones_funcaddrs_and_not_is_pic",
-        predicate!(!allones_funcaddrs && !is_pic),
+        predicate!(!emit_all_ones_funcaddrs && !is_pic),
     );
 
     // Presets corresponding to x86 CPUs.

--- a/cranelift-codegen/meta/src/shared/settings.rs
+++ b/cranelift-codegen/meta/src/shared/settings.rs
@@ -37,7 +37,7 @@ pub(crate) fn define() -> SettingGroup {
     );
 
     settings.add_bool(
-        "colocated_libcalls",
+        "use_colocated_libcalls",
         r#"
             Use colocated libcalls.
 
@@ -177,7 +177,7 @@ pub(crate) fn define() -> SettingGroup {
     // BaldrMonkey requires that not-yet-relocated function addresses be encoded
     // as all-ones bitpatterns.
     settings.add_bool(
-        "allones_funcaddrs",
+        "emit_all_ones_funcaddrs",
         "Emit not-yet-relocated function addresses as all-ones bit patterns.",
         false,
     );
@@ -185,7 +185,7 @@ pub(crate) fn define() -> SettingGroup {
     // Stack probing options.
 
     settings.add_bool(
-        "probestack_enabled",
+        "enable_probestack",
         r#"
             Enable the use of stack probes, for calling conventions which support this
             functionality.
@@ -218,7 +218,7 @@ pub(crate) fn define() -> SettingGroup {
     // Jump table options.
 
     settings.add_bool(
-        "jump_tables_enabled",
+        "enable_jump_tables",
         "Enable the use of jump tables in generated machine code.",
         true,
     );

--- a/cranelift-codegen/src/ir/libcall.rs
+++ b/cranelift-codegen/src/ir/libcall.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub enum LibCall {
     /// probe for stack overflow. These are emitted for functions which need
-    /// when the `probestack_enabled` setting is true.
+    /// when the `enable_probestack` setting is true.
     Probestack,
     /// ceil.f32
     CeilF32,
@@ -202,7 +202,7 @@ fn make_funcref(
     func.import_function(ExtFuncData {
         name: ExternalName::LibCall(libcall),
         signature: sigref,
-        colocated: isa.flags().colocated_libcalls(),
+        colocated: isa.flags().use_colocated_libcalls(),
     })
 }
 

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -449,7 +449,7 @@ pub fn prologue_epilogue(func: &mut ir::Function, isa: &dyn TargetIsa) -> Codege
 
 fn baldrdash_prologue_epilogue(func: &mut ir::Function, isa: &dyn TargetIsa) -> CodegenResult<()> {
     debug_assert!(
-        !isa.flags().probestack_enabled(),
+        !isa.flags().enable_probestack(),
         "baldrdash does not expect cranelift to emit stack probes"
     );
 
@@ -750,8 +750,7 @@ fn insert_common_prologue(
 
     // Allocate stack frame storage.
     if stack_size > 0 {
-        if isa.flags().probestack_enabled()
-            && stack_size > (1 << isa.flags().probestack_size_log2())
+        if isa.flags().enable_probestack() && stack_size > (1 << isa.flags().probestack_size_log2())
         {
             // Emit a stack probe.
             let rax = RU::rax as RegUnit;

--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -191,7 +191,7 @@ pub fn legalize_function(func: &mut ir::Function, cfg: &mut ControlFlowGraph, is
     }
 
     // Now that we've lowered all br_tables, we don't need the jump tables anymore.
-    if !isa.flags().jump_tables_enabled() {
+    if !isa.flags().enable_jump_tables() {
         pos.func.jump_tables.clear();
     }
 }
@@ -276,7 +276,7 @@ fn expand_br_table(
     cfg: &mut ControlFlowGraph,
     isa: &dyn TargetIsa,
 ) {
-    if isa.flags().jump_tables_enabled() {
+    if isa.flags().enable_jump_tables() {
         expand_br_table_jt(inst, func, cfg, isa);
     } else {
         expand_br_table_conds(inst, func, cfg, isa);

--- a/cranelift-codegen/src/settings.rs
+++ b/cranelift-codegen/src/settings.rs
@@ -384,7 +384,7 @@ mod tests {
              probestack_size_log2 = 12\n\
              enable_verifier = true\n\
              is_pic = false\n\
-             colocated_libcalls = false\n\
+             use_colocated_libcalls = false\n\
              avoid_div_traps = false\n\
              enable_float = true\n\
              enable_nan_canonicalization = false\n\
@@ -393,10 +393,10 @@ mod tests {
              enable_simd = false\n\
              enable_atomics = true\n\
              enable_safepoints = false\n\
-             allones_funcaddrs = false\n\
-             probestack_enabled = true\n\
+             emit_all_ones_funcaddrs = false\n\
+             enable_probestack = true\n\
              probestack_func_adjusts_sp = false\n\
-             jump_tables_enabled = true\n"
+             enable_jump_tables = true\n"
         );
         assert_eq!(f.opt_level(), super::OptLevel::None);
         assert_eq!(f.enable_simd(), false);

--- a/filetests/isa/x86/allones_funcaddrs32.clif
+++ b/filetests/isa/x86/allones_funcaddrs32.clif
@@ -1,7 +1,7 @@
 ; binary emission of 32-bit code.
 test binemit
 set opt_level=speed_and_size
-set allones_funcaddrs
+set emit_all_ones_funcaddrs
 target i686 haswell
 
 ; The binary encodings can be verified with the command:
@@ -9,7 +9,7 @@ target i686 haswell
 ;   sed -ne 's/^ *; asm: *//p' filetests/isa/x86/allones_funcaddrs32.clif | llvm-mc -show-encoding -triple=i386
 ;
 
-; Tests from binary32.clif affected by allones_funcaddrs.
+; Tests from binary32.clif affected by emit_all_ones_funcaddrs.
 function %I32() {
     sig0 = ()
     fn0 = %foo()

--- a/filetests/isa/x86/allones_funcaddrs64.clif
+++ b/filetests/isa/x86/allones_funcaddrs64.clif
@@ -1,7 +1,7 @@
 ; binary emission of 64-bit code.
 test binemit
 set opt_level=speed_and_size
-set allones_funcaddrs
+set emit_all_ones_funcaddrs
 target x86_64 haswell
 
 ; The binary encodings can be verified with the command:
@@ -9,7 +9,7 @@ target x86_64 haswell
 ;   sed -ne 's/^ *; asm: *//p' filetests/isa/x86/allones_funcaddrs64.clif | llvm-mc -show-encoding -triple=x86_64
 ;
 
-; Tests from binary64.clif affected by allones_funcaddrs.
+; Tests from binary64.clif affected by emit_all_ones_funcaddrs.
 function %I64() {
     sig0 = ()
     fn0 = %foo()

--- a/filetests/isa/x86/baldrdash-table-sig-reg.clif
+++ b/filetests/isa/x86/baldrdash-table-sig-reg.clif
@@ -1,5 +1,5 @@
 test compile
-set probestack_enabled=false
+set enable_probestack=false
 target i686
 
 function u0:0(i32 vmctx) baldrdash_system_v {

--- a/filetests/isa/x86/compile-vconst.clif
+++ b/filetests/isa/x86/compile-vconst.clif
@@ -1,6 +1,6 @@
 test compile
 set enable_simd=true
-set probestack_enabled=false
+set enable_probestack=false
 target x86_64 haswell
 
 ; use baldrdash calling convention here for simplicity (avoids prologue, epilogue)

--- a/filetests/isa/x86/legalize-splat.clif
+++ b/filetests/isa/x86/legalize-splat.clif
@@ -1,6 +1,6 @@
 test compile
 set enable_simd=true
-set probestack_enabled=false
+set enable_probestack=false
 target x86_64 haswell
 
 ; use baldrdash_system_v calling convention here for simplicity (avoids prologue, epilogue)

--- a/filetests/isa/x86/probestack-adjusts-sp.clif
+++ b/filetests/isa/x86/probestack-adjusts-sp.clif
@@ -1,5 +1,5 @@
 test compile
-set colocated_libcalls=1
+set use_colocated_libcalls=1
 set probestack_func_adjusts_sp=1
 target x86_64
 

--- a/filetests/isa/x86/probestack-disabled.clif
+++ b/filetests/isa/x86/probestack-disabled.clif
@@ -1,6 +1,6 @@
 test compile
-set colocated_libcalls=1
-set probestack_enabled=0
+set use_colocated_libcalls=1
+set enable_probestack=0
 target x86_64
 
 ; Like %big in probestack.clif, but with probes disabled.

--- a/filetests/isa/x86/probestack-size.clif
+++ b/filetests/isa/x86/probestack-size.clif
@@ -1,5 +1,5 @@
 test compile
-set colocated_libcalls=1
+set use_colocated_libcalls=1
 set probestack_size_log2=13
 target x86_64
 

--- a/filetests/isa/x86/probestack.clif
+++ b/filetests/isa/x86/probestack.clif
@@ -1,5 +1,5 @@
 test compile
-set colocated_libcalls=1
+set use_colocated_libcalls=1
 target x86_64
 
 ; A function with a big stack frame. This should have a stack probe.

--- a/filetests/isa/x86/relax_branch.clif
+++ b/filetests/isa/x86/relax_branch.clif
@@ -2,8 +2,8 @@ test binemit
 set opt_level=speed_and_size
 set avoid_div_traps
 set baldrdash_prologue_words=3
-set allones_funcaddrs
-set probestack_enabled=false
+set emit_all_ones_funcaddrs
+set enable_probestack=false
 target x86_64 haswell
 
 ; This checks that a branch that is too far away is getting relaxed. In

--- a/filetests/isa/x86/scalar_to_vector-compile.clif
+++ b/filetests/isa/x86/scalar_to_vector-compile.clif
@@ -1,6 +1,6 @@
 test compile
 set opt_level=speed_and_size
-set probestack_enabled=false
+set enable_probestack=false
 set enable_simd
 target x86_64
 

--- a/filetests/legalizer/br_table_cond.clif
+++ b/filetests/legalizer/br_table_cond.clif
@@ -1,6 +1,6 @@
 test legalizer
-set probestack_enabled=false
-set jump_tables_enabled=false
+set enable_probestack=false
+set enable_jump_tables=false
 target x86_64
 
 ; Test that when jump_tables_enables is false, all jump tables are eliminated.

--- a/filetests/legalizer/empty_br_table.clif
+++ b/filetests/legalizer/empty_br_table.clif
@@ -1,6 +1,6 @@
 test legalizer
-set probestack_enabled=false
-set jump_tables_enabled=false
+set enable_probestack=false
+set enable_jump_tables=false
 target x86_64
 
 function u0:0(i64) {

--- a/filetests/regalloc/unreachable_code.clif
+++ b/filetests/regalloc/unreachable_code.clif
@@ -1,7 +1,7 @@
 ; Use "test compile" here otherwise the dead blocks won't be eliminated.
 test compile
 
-set probestack_enabled=0
+set enable_probestack=0
 target x86_64 haswell
 
 ; This function contains unreachable blocks which trip up the register


### PR DESCRIPTION
This is a breaking API change: the following settings have been renamed:

- jump_tables_enabled -> enable_jump_tables
- colocated_libcalls -> use_colocated_libcalls
- probestack_enabled -> enable_probestack
- allones_funcaddrs -> emit_all_ones_funcaddrs

- [x] #976 
- [x] This PR contains test cases, if meaningful.
- [x] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.

<!-- Please ensure all communication adheres to the [code of
conduct](https://github.com/CraneStation/cranelift/blob/master/CODE_OF_CONDUCT.md). -->
