### PR TITLE
Require the `Send` trait for `TargetIsa`

### DIFF
--- a/cranelift-codegen/src/isa/mod.rs
+++ b/cranelift-codegen/src/isa/mod.rs
@@ -198,7 +198,7 @@ impl TargetFrontendConfig {
 
 /// Methods that are specialized to a target ISA. Implies a Display trait that shows the
 /// shared flags, as well as any isa-specific flags.
-pub trait TargetIsa: fmt::Display + Sync {
+pub trait TargetIsa: fmt::Display + Send + Sync {
     /// Get the name of this ISA.
     fn name(&self) -> &'static str;
 


### PR DESCRIPTION
The `TargetIsa` trait already requires that the implementor is `Sync` to
be shared across threads, and this commit adds in an additional
restriction of `Send` to ensure that the type can be sent-by-value
across threads as well.

This is part of an effort to make various data structures in `wasmtime`
sendable/shareable across threads.
