### PR TITLE
Fix clippy warnings in EncodingBits

### DIFF
--- a/cranelift-codegen/shared/src/isa/x86/encoding_bits.rs
+++ b/cranelift-codegen/shared/src/isa/x86/encoding_bits.rs
@@ -59,20 +59,18 @@ impl EncodingBits {
 
     /// Returns a copy of the EncodingBits with the RRR bits set.
     #[inline]
-    pub fn with_rrr(self, rrr: u8) -> Self {
-        debug_assert_eq!(u8::from(self.rrr()), 0);
-        let mut enc = self.clone();
-        enc.write(RRR, rrr.into());
-        enc
+    pub fn with_rrr(mut self, rrr: u8) -> Self {
+        debug_assert_eq!(self.rrr(), 0);
+        self.write(RRR, rrr.into());
+        self
     }
 
     /// Returns a copy of the EncodingBits with the REX.W bit set.
     #[inline]
-    pub fn with_rex_w(self) -> Self {
+    pub fn with_rex_w(mut self) -> Self {
         debug_assert_eq!(self.rex_w(), 0);
-        let mut enc = self.clone();
-        enc.write(REX_W, 1);
-        enc
+        self.write(REX_W, 1);
+        self
     }
 
     /// Returns the raw bits.

--- a/cranelift-codegen/src/ir/framelayout.rs
+++ b/cranelift-codegen/src/ir/framelayout.rs
@@ -56,7 +56,7 @@ pub struct FrameLayout {
 impl FrameLayout {
     /// Create instance of FrameLayout.
     pub fn new() -> Self {
-        FrameLayout {
+        Self {
             initial: vec![].into_boxed_slice(),
             instructions: HashMap::new(),
         }

--- a/cranelift-codegen/src/isa/x86/binemit.rs
+++ b/cranelift-codegen/src/isa/x86/binemit.rs
@@ -64,7 +64,7 @@ fn rex3(rm: RegUnit, reg: RegUnit, index: RegUnit) -> u8 {
 /// Determines whether a REX prefix should be emitted.
 #[inline]
 fn needs_rex(bits: u16, rex: u8) -> bool {
-    rex != BASE_REX || u8::from(EncodingBits::from(bits).rex_w()) == 1
+    rex != BASE_REX || EncodingBits::from(bits).rex_w() == 1
 }
 
 // Emit a REX prefix.
@@ -74,7 +74,7 @@ fn needs_rex(bits: u16, rex: u8) -> bool {
 fn rex_prefix<CS: CodeSink + ?Sized>(bits: u16, rex: u8, sink: &mut CS) {
     debug_assert_eq!(rex & 0xf8, BASE_REX);
     let w = EncodingBits::from(bits).rex_w();
-    sink.put1(rex | (u8::from(w) << 3));
+    sink.put1(rex | (w << 3));
 }
 
 // Emit a single-byte opcode with no REX prefix.

--- a/cranelift-codegen/src/simple_gvn.rs
+++ b/cranelift-codegen/src/simple_gvn.rs
@@ -124,7 +124,8 @@ pub fn do_simple_gvn(func: &mut Function, domtree: &mut DominatorTree) {
             use crate::scoped_hash_map::Entry::*;
             match visible_values.entry(key) {
                 Occupied(entry) => {
-                    debug_assert!(domtree.dominates(*entry.get(), inst, &func.layout));
+                    let layout = &func.layout;
+                    debug_assert!(domtree.dominates(*entry.get(), inst, layout));
                     // If the redundant instruction is representing the current
                     // scope, pick a new representative.
                     let old = scope_stack.last_mut().unwrap();

--- a/cranelift-wasm/src/environ/spec.rs
+++ b/cranelift-wasm/src/environ/spec.rs
@@ -302,6 +302,7 @@ pub trait FuncEnvironment: TargetEnvironment {
     /// The `index` provided identifies the linear memory to query, and `heap` is the heap reference
     /// returned by `make_heap` for the same index. `seg_index` is the index of the segment to copy
     /// from.
+    #[allow(clippy::too_many_arguments)]
     fn translate_memory_init(
         &mut self,
         pos: FuncCursor,
@@ -325,6 +326,7 @@ pub trait FuncEnvironment: TargetEnvironment {
     ) -> WasmResult<ir::Value>;
 
     /// Translate a `table.copy` WebAssembly instruction.
+    #[allow(clippy::too_many_arguments)]
     fn translate_table_copy(
         &mut self,
         pos: FuncCursor,
@@ -338,6 +340,7 @@ pub trait FuncEnvironment: TargetEnvironment {
     ) -> WasmResult<()>;
 
     /// Translate a `table.init` WebAssembly instruction.
+    #[allow(clippy::too_many_arguments)]
     fn translate_table_init(
         &mut self,
         pos: FuncCursor,


### PR DESCRIPTION
Prior to this I would see the following on `cargo build`:

```
$ cargo build
warning: identical conversion
  --> cranelift-codegen/shared/src/isa/x86/encoding_bits.rs:63:26
   |
63 |         debug_assert_eq!(u8::from(self.rrr()), 0);
   |                          ^^^^^^^^^^^^^^^^^^^^ help: consider removing `u8::from()`: `self.rrr()`
   |
   = note: `#[warn(clippy::identity_conversion)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion

warning: using `clone` on a `Copy` type
  --> cranelift-codegen/shared/src/isa/x86/encoding_bits.rs:64:23
   |
64 |         let mut enc = self.clone();
   |                       ^^^^^^^^^^^^ help: try removing the `clone` call: `self`
   |
   = note: `#[warn(clippy::clone_on_copy)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy

warning: using `clone` on a `Copy` type
  --> cranelift-codegen/shared/src/isa/x86/encoding_bits.rs:73:23
   |
73 |         let mut enc = self.clone();
   |                       ^^^^^^^^^^^^ help: try removing the `clone` call: `self`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy

    Finished dev [unoptimized + debuginfo] target(s) in 0.04s

```