### PR TITLE
When splitting a const, insert prior to the terminal branch group.

### DIFF
--- a/filetests/verifier/isplit-bb.clif
+++ b/filetests/verifier/isplit-bb.clif
@@ -1,0 +1,28 @@
+test compile
+target x86_64
+
+function u0:0(i128, i128, i64) -> i128 system_v {
+    ebb0(v0: i128, v1: i128, v2: i64):
+        trap user0
+
+    ebb1:
+        v10 = iconst.i64 0
+        v11 = iconst.i64 0
+        v17 = iconcat v10, v11
+        v12 = iconst.i64 0
+        v13 = iconst.i64 0 
+        v20 = iconcat v12, v13
+        trap user0
+
+    ebb79:
+        v425 = iconst.i64 0
+        v426 = icmp_imm eq v425, 1
+        brnz v426, ebb80
+        jump ebb85(v20, v17)
+
+    ebb80:
+        trap user0
+
+    ebb85(v462: i128, v874: i128):
+        trap user0
+}


### PR DESCRIPTION
Closes #1159 

Given code like the following, on x86_64, which does not have i128 registers:

    ebb0(v0: i64):
        v1 = iconst.i128 0
        v2 = icmp_imm eq v0, 1
        brnz v2, ebb1
        jump ebb2(v1)

It would be split to:

    ebb0(v0: i64):
        v1 = iconst.i128 0
        v2 = icmp_imm eq v0, 1
        brnz v2, ebb1
        v3, v4 = isplit.i128 v1
        jump ebb2(v3, v4)

But that fails basic-block invariants. This patch changes that to:

    ebb0(v0: i64):
        v1 = iconst.i128 0
        v2 = icmp_imm eq v0, 1
        v3, v4 = isplit.i128 v1
        brnz v2, ebb1
        jump ebb2(v3, v4)

- [x] This has been discussed in issue #1159 .

I decided to move the `isplit` before the terminal branch group to keep the invariants simple: in that issue it was suggested that we solve this by allowing `isplit` instructions within the branch group, but in prior patches it was common need to have to inspect multiple branches in the same terminal group. If we allowed `isplit` there, many places throughout the code would have to learn how to ignore those instructions. Moving the `isplit` prior to all branches is a lower cognitive burden.

- [x] A short description of what this does, why it is needed.
- [x] This PR contains test cases, if meaningful.
- [x] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.