### PR TITLE
Add a `is_wasm_parameter` method to the wasm `FuncEnvironment`.

### DIFF
--- a/cranelift-wasm/src/environ/dummy.rs
+++ b/cranelift-wasm/src/environ/dummy.rs
@@ -201,6 +201,10 @@ impl<'dummy_environment> TargetEnvironment for DummyFuncEnvironment<'dummy_envir
 }
 
 impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environment> {
+    fn is_wasm_parameter(&self, func: &ir::Function, index: usize) -> bool {
+        func.signature.params[index].purpose == ir::ArgumentPurpose::Normal
+    }
+
     fn return_mode(&self) -> ReturnMode {
         self.return_mode
     }

--- a/cranelift-wasm/src/environ/spec.rs
+++ b/cranelift-wasm/src/environ/spec.rs
@@ -138,6 +138,10 @@ pub trait TargetEnvironment {
 /// IR. The function environment provides information about the WebAssembly module as well as the
 /// runtime environment.
 pub trait FuncEnvironment: TargetEnvironment {
+    /// Is the given parameter of the given function a wasm-level parameter, as opposed to a hidden
+    /// parameter added for use by the implementation?
+    fn is_wasm_parameter(&self, func: &ir::Function, index: usize) -> bool;
+
     /// Should the code be structured to use a single `fallthrough_return` instruction at the end
     /// of the function body, rather than `return` instructions as needed? This is used by VMs
     /// to append custom epilogues.

--- a/cranelift-wasm/src/func_translator.rs
+++ b/cranelift-wasm/src/func_translator.rs
@@ -99,7 +99,7 @@ impl FuncTranslator {
         // `environ`. The callback functions may need to insert things in the entry block.
         builder.ensure_inserted_ebb();
 
-        let num_params = declare_wasm_parameters(&mut builder, entry_block);
+        let num_params = declare_wasm_parameters(&mut builder, entry_block, environ);
 
         // Set up the translation state with a single pushed control block representing the whole
         // function and its return values.
@@ -124,14 +124,18 @@ impl FuncTranslator {
 /// Declare local variables for the signature parameters that correspond to WebAssembly locals.
 ///
 /// Return the number of local variables declared.
-fn declare_wasm_parameters(builder: &mut FunctionBuilder, entry_block: Ebb) -> usize {
+fn declare_wasm_parameters<FE: FuncEnvironment + ?Sized>(
+    builder: &mut FunctionBuilder,
+    entry_block: Ebb,
+    environ: &FE,
+) -> usize {
     let sig_len = builder.func.signature.params.len();
     let mut next_local = 0;
     for i in 0..sig_len {
         let param_type = builder.func.signature.params[i];
-        // There may be additional special-purpose parameters following the normal WebAssembly
+        // There may be additional special-purpose parameters in addition to the normal WebAssembly
         // signature parameters. For example, a `vmctx` pointer.
-        if param_type.purpose == ir::ArgumentPurpose::Normal {
+        if environ.is_wasm_parameter(&builder.func, i) {
             // This is a normal WebAssembly signature parameter, so create a local for it.
             let local = Variable::new(next_local);
             builder.declare_var(local, param_type.value_type);


### PR DESCRIPTION
This provides a more flexible way to allow embedding to tell
cranelift-wasm which function parameters are hidden, and which should be
translated as wasm user variables.

This replaces https://github.com/bytecodealliance/cranelift/pull/1086.

- [X] This has been discussed in issue #1086
- [X] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [X] This PR contains test cases, if meaningful. No tests as this doesn't change any functionality.
- [X] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.

<!-- Please ensure all communication adheres to the [code of
conduct](https://github.com/CraneStation/cranelift/blob/master/CODE_OF_CONDUCT.md). -->
