### PR TITLE
Verify that EBBs are non-empty

### DIFF
--- a/cranelift-codegen/src/verifier/mod.rs
+++ b/cranelift-codegen/src/verifier/mod.rs
@@ -1971,6 +1971,9 @@ impl<'a> Verifier<'a> {
         self.typecheck_function_signature(errors)?;
 
         for ebb in self.func.layout.ebbs() {
+            if self.func.layout.first_inst(ebb).is_none() {
+                return errors.fatal((ebb, format!("{} cannot be empty", ebb)));
+            }
             for inst in self.func.layout.ebb_insts(ebb) {
                 self.ebb_integrity(ebb, inst, errors)?;
                 self.instruction_integrity(inst, errors)?;
@@ -2116,5 +2119,19 @@ mod tests {
             format!("{}", errors.0[0]),
             "inst0 (v0, v1 = iconst.i32 42): has more result values than expected"
         )
+    }
+
+    #[test]
+    fn test_empty_ebb() {
+        let mut func = Function::new();
+        let ebb0 = func.dfg.make_ebb();
+        func.layout.append_ebb(ebb0);
+
+        let flags = &settings::Flags::new(settings::builder());
+        let verifier = Verifier::new(&func, flags.into());
+        let mut errors = VerifierErrors::default();
+        let _ = verifier.run(&mut errors);
+
+        assert_err_with_msg!(errors, "ebb0 cannot be empty");
     }
 }


### PR DESCRIPTION
Fixes #1059.

This will return a verifier error if an empty ebb is found.

- [x] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.