### PR TITLE
Try to reduce CI times with a Rust `*.wat` parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ clap = "2.32.0"
 serde = "1.0.8"
 term = "0.6.1"
 capstone = { version = "0.6.0", optional = true }
-wabt = { version = "0.9.1", optional = true }
+wat = { version = "1.0.7", optional = true }
 target-lexicon = "0.10"
 pretty_env_logger = "0.3.0"
 file-per-thread-logger = "0.1.2"
@@ -48,7 +48,7 @@ walkdir = "2.2"
 [features]
 default = ["disas", "wasm", "cranelift-codegen/all-arch", "basic-blocks"]
 disas = ["capstone"]
-wasm = ["wabt", "cranelift-wasm"]
+wasm = ["wat", "cranelift-wasm"]
 basic-blocks = ["cranelift-codegen/basic-blocks", "cranelift-frontend/basic-blocks",
 "cranelift-wasm/basic-blocks", "cranelift-filetests/basic-blocks"]
 

--- a/cranelift-wasm/Cargo.toml
+++ b/cranelift-wasm/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.94", features = ["derive"], optional = true }
 thiserror = "1.0.4"
 
 [dev-dependencies]
-wabt = "0.9.1"
+wat = "1.0.7"
 target-lexicon = "0.10"
 
 [features]

--- a/src/clif-util.rs
+++ b/src/clif-util.rs
@@ -107,24 +107,6 @@ fn add_debug_flag<'a>() -> clap::Arg<'a, 'a> {
         .help("Enable debug output on stderr/stdout")
 }
 
-fn add_enable_simd_flag<'a>() -> clap::Arg<'a, 'a> {
-    Arg::with_name("enable-simd")
-        .long("enable-simd")
-        .help("Enable WASM's SIMD operations")
-}
-
-fn add_enable_multi_value<'a>() -> clap::Arg<'a, 'a> {
-    Arg::with_name("enable-multi-value")
-        .long("enable-multi-value")
-        .help("Enable WASM's multi-value support")
-}
-
-fn add_enable_reference_types_flag<'a>() -> clap::Arg<'a, 'a> {
-    Arg::with_name("enable-reference-types")
-        .long("enable-reference-types")
-        .help("Enable WASM's reference types operations")
-}
-
 fn add_just_decode_flag<'a>() -> clap::Arg<'a, 'a> {
     Arg::with_name("just-decode")
         .short("t")
@@ -167,9 +149,6 @@ fn add_wasm_or_compile<'a>(cmd: &str) -> clap::App<'a, 'a> {
         .arg(add_target_flag())
         .arg(add_input_file_arg())
         .arg(add_debug_flag())
-        .arg(add_enable_simd_flag())
-        .arg(add_enable_multi_value())
-        .arg(add_enable_reference_types_flag())
         .arg(add_just_decode_flag())
         .arg(add_check_translation_flag())
 }
@@ -321,9 +300,6 @@ fn main() {
                     rest_cmd.is_present("print-size"),
                     rest_cmd.is_present("time-passes"),
                     rest_cmd.is_present("value-ranges"),
-                    rest_cmd.is_present("enable-simd"),
-                    rest_cmd.is_present("enable-multi-value"),
-                    rest_cmd.is_present("enable-reference-types"),
                 )
             };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,21 +24,6 @@ pub fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
     Ok(buffer)
 }
 
-/// Read an entire file into a vector of bytes.
-#[cfg(feature = "wasm")]
-pub fn read_to_end<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
-    let mut buffer = Vec::new();
-    if path.as_ref() == Path::new("-") {
-        let stdin = io::stdin();
-        let mut stdin = stdin.lock();
-        stdin.read_to_end(&mut buffer)?;
-    } else {
-        let mut file = File::open(path)?;
-        file.read_to_end(&mut buffer)?;
-    }
-    Ok(buffer)
-}
-
 /// Like `FlagsOrIsa`, but holds ownership.
 pub enum OwnedFlagsOrIsa {
     Flags(settings::Flags),


### PR DESCRIPTION
This commit moves the cranelift tests and tools from the `wabt` crate on
crates.io (which compiles the wabt C++ codebase) to the `wat` crate on
crates.io which is a Rust parser for the `*.wat` format. This was
motivated by me noticing that release builds on Windows are ~5 minutes
longer than Linux builds, and local timing graphs showed that `wabt-sys`
was by far the longest build step in the build process.

This commit changes the `clif-util` binary where the `--enable-simd`
flag is no longer respected with the text format as input, since the
`wat` crate has no feature gating. This was already sort of not
respected, though, since `--enable-simd` wasn't consulted for binary
inputs which `clif-util` supports as well. If this isn't ok though then
it should be ok to close this PR!
