### PR TITLE
Add a reminder to create the PR to the end of the publish script.

### DIFF
--- a/publish-all.sh
+++ b/publish-all.sh
@@ -51,3 +51,7 @@ do
     # https://internals.rust-lang.org/t/changes-to-how-crates-io-handles-index-updates/9608
     echo sleep 10
 done
+echo
+echo "echo \"#\""
+echo "echo \"# Don't forget to click the above link to open a pull-request!\""
+echo "echo \"#\""


### PR DESCRIPTION
With all the sleeps between commands, the publish script takes a few
miniutes to run, and it can be easy to forget to create the PR when it
finishes. Add a reminder to be displayed at the end of the script.

(Skipping the template because this is a simple change.)