### PR TITLE
implement Debug for ObjectBackend

### DIFF
--- a/cranelift-object/src/backend.rs
+++ b/cranelift-object/src/backend.rs
@@ -478,6 +478,7 @@ pub struct ObjectCompiledData {
 /// [`finish`](../cranelift_module/struct.Module.html#method.finish) function.
 /// It contains the generated `Object` and other information produced during
 /// compilation.
+#[derive(Debug)]
 pub struct ObjectProduct {
     /// Object artifact with all functions and data from the module defined.
     pub object: Object,


### PR DESCRIPTION
- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.

This change is trival.

- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.

This allows using `.unwrap_err()` on `Result<ObjectBackend, E>`.

- [ ] This PR contains test cases, if meaningful.

N/A

- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.

@bnjbvr I am not sure who could review since @philipc  is not part of the core team.