### PR TITLE
Fix remaining clippy warnings

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -1346,7 +1346,7 @@ mod test {
         let type1 = TypeSetBuilder::new().ints(8..64).build();
         let in1 = OperandKindFields::TypeVar(TypeVar::new("a", "...", type1));
         let inst = build_fake_instruction(vec![in1], vec![]);
-        inst.bind(LaneType::IntType(I32));
+        inst.bind(LaneType::Int(I32));
     }
 
     #[test]
@@ -1360,7 +1360,7 @@ mod test {
     #[should_panic]
     fn ensure_instructions_fail_to_bind() {
         let inst = build_fake_instruction(vec![], vec![]);
-        inst.bind(BindParameter::Lane(LaneType::IntType(I32)));
+        inst.bind(BindParameter::Lane(LaneType::Int(I32)));
         // Trying to bind to an instruction with no inputs should fail.
     }
 
@@ -1370,8 +1370,7 @@ mod test {
         let type1 = TypeSetBuilder::new().ints(8..64).build();
         let in1 = OperandKindFields::TypeVar(TypeVar::new("a", "...", type1));
         let inst = build_fake_instruction(vec![in1], vec![]);
-        inst.bind(LaneType::IntType(I32))
-            .bind(LaneType::IntType(I64));
+        inst.bind(LaneType::Int(I32)).bind(LaneType::Int(I64));
     }
 
     #[test]

--- a/cranelift-codegen/meta/src/cdsl/types.rs
+++ b/cranelift-codegen/meta/src/cdsl/types.rs
@@ -140,42 +140,42 @@ impl From<VectorType> for ValueType {
 /// A concrete scalar type that can appear as a vector lane too.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum LaneType {
-    BoolType(shared_types::Bool),
-    FloatType(shared_types::Float),
-    IntType(shared_types::Int),
+    Bool(shared_types::Bool),
+    Float(shared_types::Float),
+    Int(shared_types::Int),
 }
 
 impl LaneType {
     /// Return a string containing the documentation comment for this lane type.
     pub fn doc(self) -> String {
         match self {
-            LaneType::BoolType(_) => format!("A boolean type with {} bits.", self.lane_bits()),
-            LaneType::FloatType(shared_types::Float::F32) => String::from(
+            LaneType::Bool(_) => format!("A boolean type with {} bits.", self.lane_bits()),
+            LaneType::Float(shared_types::Float::F32) => String::from(
                 "A 32-bit floating point type represented in the IEEE 754-2008
                 *binary32* interchange format. This corresponds to the :c:type:`float`
                 type in most C implementations.",
             ),
-            LaneType::FloatType(shared_types::Float::F64) => String::from(
+            LaneType::Float(shared_types::Float::F64) => String::from(
                 "A 64-bit floating point type represented in the IEEE 754-2008
                 *binary64* interchange format. This corresponds to the :c:type:`double`
                 type in most C implementations.",
             ),
-            LaneType::IntType(_) if self.lane_bits() < 32 => format!(
+            LaneType::Int(_) if self.lane_bits() < 32 => format!(
                 "An integer type with {} bits.
                 WARNING: arithmetic on {}bit integers is incomplete",
                 self.lane_bits(),
                 self.lane_bits()
             ),
-            LaneType::IntType(_) => format!("An integer type with {} bits.", self.lane_bits()),
+            LaneType::Int(_) => format!("An integer type with {} bits.", self.lane_bits()),
         }
     }
 
     /// Return the number of bits in a lane.
     pub fn lane_bits(self) -> u64 {
         match self {
-            LaneType::BoolType(ref b) => *b as u64,
-            LaneType::FloatType(ref f) => *f as u64,
-            LaneType::IntType(ref i) => *i as u64,
+            LaneType::Bool(ref b) => *b as u64,
+            LaneType::Float(ref f) => *f as u64,
+            LaneType::Int(ref i) => *i as u64,
         }
     }
 
@@ -183,24 +183,24 @@ impl LaneType {
     pub fn number(self) -> u8 {
         constants::LANE_BASE
             + match self {
-                LaneType::BoolType(shared_types::Bool::B1) => 0,
-                LaneType::BoolType(shared_types::Bool::B8) => 1,
-                LaneType::BoolType(shared_types::Bool::B16) => 2,
-                LaneType::BoolType(shared_types::Bool::B32) => 3,
-                LaneType::BoolType(shared_types::Bool::B64) => 4,
-                LaneType::BoolType(shared_types::Bool::B128) => 5,
-                LaneType::IntType(shared_types::Int::I8) => 6,
-                LaneType::IntType(shared_types::Int::I16) => 7,
-                LaneType::IntType(shared_types::Int::I32) => 8,
-                LaneType::IntType(shared_types::Int::I64) => 9,
-                LaneType::IntType(shared_types::Int::I128) => 10,
-                LaneType::FloatType(shared_types::Float::F32) => 11,
-                LaneType::FloatType(shared_types::Float::F64) => 12,
+                LaneType::Bool(shared_types::Bool::B1) => 0,
+                LaneType::Bool(shared_types::Bool::B8) => 1,
+                LaneType::Bool(shared_types::Bool::B16) => 2,
+                LaneType::Bool(shared_types::Bool::B32) => 3,
+                LaneType::Bool(shared_types::Bool::B64) => 4,
+                LaneType::Bool(shared_types::Bool::B128) => 5,
+                LaneType::Int(shared_types::Int::I8) => 6,
+                LaneType::Int(shared_types::Int::I16) => 7,
+                LaneType::Int(shared_types::Int::I32) => 8,
+                LaneType::Int(shared_types::Int::I64) => 9,
+                LaneType::Int(shared_types::Int::I128) => 10,
+                LaneType::Float(shared_types::Float::F32) => 11,
+                LaneType::Float(shared_types::Float::F64) => 12,
             }
     }
 
     pub fn bool_from_bits(num_bits: u16) -> LaneType {
-        LaneType::BoolType(match num_bits {
+        LaneType::Bool(match num_bits {
             1 => shared_types::Bool::B1,
             8 => shared_types::Bool::B8,
             16 => shared_types::Bool::B16,
@@ -212,7 +212,7 @@ impl LaneType {
     }
 
     pub fn int_from_bits(num_bits: u16) -> LaneType {
-        LaneType::IntType(match num_bits {
+        LaneType::Int(match num_bits {
             8 => shared_types::Int::I8,
             16 => shared_types::Int::I16,
             32 => shared_types::Int::I32,
@@ -223,7 +223,7 @@ impl LaneType {
     }
 
     pub fn float_from_bits(num_bits: u16) -> LaneType {
-        LaneType::FloatType(match num_bits {
+        LaneType::Float(match num_bits {
             32 => shared_types::Float::F32,
             64 => shared_types::Float::F64,
             _ => unreachable!("unxpected num bits for float"),
@@ -240,14 +240,14 @@ impl LaneType {
 
     pub fn is_float(self) -> bool {
         match self {
-            LaneType::FloatType(_) => true,
+            LaneType::Float(_) => true,
             _ => false,
         }
     }
 
     pub fn is_int(self) -> bool {
         match self {
-            LaneType::IntType(_) => true,
+            LaneType::Int(_) => true,
             _ => false,
         }
     }
@@ -256,9 +256,9 @@ impl LaneType {
 impl fmt::Display for LaneType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            LaneType::BoolType(_) => write!(f, "b{}", self.lane_bits()),
-            LaneType::FloatType(_) => write!(f, "f{}", self.lane_bits()),
-            LaneType::IntType(_) => write!(f, "i{}", self.lane_bits()),
+            LaneType::Bool(_) => write!(f, "b{}", self.lane_bits()),
+            LaneType::Float(_) => write!(f, "f{}", self.lane_bits()),
+            LaneType::Int(_) => write!(f, "i{}", self.lane_bits()),
         }
     }
 }
@@ -270,9 +270,9 @@ impl fmt::Debug for LaneType {
             f,
             "{}",
             match *self {
-                LaneType::BoolType(_) => format!("BoolType({})", inner_msg),
-                LaneType::FloatType(_) => format!("FloatType({})", inner_msg),
-                LaneType::IntType(_) => format!("IntType({})", inner_msg),
+                LaneType::Bool(_) => format!("BoolType({})", inner_msg),
+                LaneType::Float(_) => format!("FloatType({})", inner_msg),
+                LaneType::Int(_) => format!("IntType({})", inner_msg),
             }
         )
     }
@@ -281,21 +281,21 @@ impl fmt::Debug for LaneType {
 /// Create a LaneType from a given bool variant.
 impl From<shared_types::Bool> for LaneType {
     fn from(b: shared_types::Bool) -> Self {
-        LaneType::BoolType(b)
+        LaneType::Bool(b)
     }
 }
 
 /// Create a LaneType from a given float variant.
 impl From<shared_types::Float> for LaneType {
     fn from(f: shared_types::Float) -> Self {
-        LaneType::FloatType(f)
+        LaneType::Float(f)
     }
 }
 
 /// Create a LaneType from a given int variant.
 impl From<shared_types::Int> for LaneType {
     fn from(i: shared_types::Int) -> Self {
-        LaneType::IntType(i)
+        LaneType::Int(i)
     }
 }
 

--- a/cranelift-codegen/meta/src/cdsl/typevar.rs
+++ b/cranelift-codegen/meta/src/cdsl/typevar.rs
@@ -73,15 +73,15 @@ impl TypeVar {
         builder = builder.simd_lanes(num_lanes..num_lanes);
 
         let builder = match scalar_type {
-            LaneType::IntType(int_type) => {
+            LaneType::Int(int_type) => {
                 let bits = int_type as RangeBound;
                 builder.ints(bits..bits)
             }
-            LaneType::FloatType(float_type) => {
+            LaneType::Float(float_type) => {
                 let bits = float_type as RangeBound;
                 builder.floats(bits..bits)
             }
-            LaneType::BoolType(bool_type) => {
+            LaneType::Bool(bool_type) => {
                 let bits = bool_type as RangeBound;
                 builder.bools(bits..bits)
             }
@@ -1200,8 +1200,7 @@ fn test_typevar_singleton() {
     use crate::shared::types as shared_types;
 
     // Test i32.
-    let typevar =
-        TypeVar::new_singleton(ValueType::Lane(LaneType::IntType(shared_types::Int::I32)));
+    let typevar = TypeVar::new_singleton(ValueType::Lane(LaneType::Int(shared_types::Int::I32)));
     assert_eq!(typevar.name, "i32");
     assert_eq!(typevar.type_set.ints, num_set![32]);
     assert!(typevar.type_set.floats.is_empty());
@@ -1211,7 +1210,7 @@ fn test_typevar_singleton() {
 
     // Test f32x4.
     let typevar = TypeVar::new_singleton(ValueType::Vector(VectorType::new(
-        LaneType::FloatType(shared_types::Float::F32),
+        LaneType::Float(shared_types::Float::F32),
         4,
     )));
     assert_eq!(typevar.name, "f32x4");

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -1530,6 +1530,7 @@ fn define_alu(
 }
 
 #[inline(never)]
+#[allow(clippy::cognitive_complexity)]
 fn define_simd(
     e: &mut PerCpuModeEncodings,
     shared_defs: &SharedDefinitions,

--- a/cranelift-codegen/src/simple_gvn.rs
+++ b/cranelift-codegen/src/simple_gvn.rs
@@ -124,8 +124,13 @@ pub fn do_simple_gvn(func: &mut Function, domtree: &mut DominatorTree) {
             use crate::scoped_hash_map::Entry::*;
             match visible_values.entry(key) {
                 Occupied(entry) => {
-                    let layout = &func.layout;
-                    debug_assert!(domtree.dominates(*entry.get(), inst, layout));
+                    #[allow(clippy::debug_assert_with_mut_call)]
+                    {
+                        // Clippy incorrectly believes `&func.layout` should not be used here:
+                        // https://github.com/rust-lang/rust-clippy/issues/4737
+                        debug_assert!(domtree.dominates(*entry.get(), inst, &func.layout));
+                    }
+
                     // If the redundant instruction is representing the current
                     // scope, pick a new representative.
                     let old = scope_stack.last_mut().unwrap();

--- a/cranelift-filetests/src/test_fde.rs
+++ b/cranelift-filetests/src/test_fde.rs
@@ -113,13 +113,13 @@ mod dwarfdump {
 
     impl From<gimli::Error> for Error {
         fn from(err: gimli::Error) -> Self {
-            Error::GimliError(err)
+            Self::GimliError(err)
         }
     }
 
     impl From<fmt::Error> for Error {
         fn from(_: fmt::Error) -> Self {
-            Error::IoError
+            Self::IoError
         }
     }
 

--- a/cranelift-frontend/src/lib.rs
+++ b/cranelift-frontend/src/lib.rs
@@ -75,92 +75,90 @@
 //! use cranelift_codegen::verifier::verify_function;
 //! use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
 //!
-//! fn main() {
-//!     let mut sig = Signature::new(CallConv::SystemV);
-//!     sig.returns.push(AbiParam::new(I32));
-//!     sig.params.push(AbiParam::new(I32));
-//!     let mut fn_builder_ctx = FunctionBuilderContext::new();
-//!     let mut func = Function::with_name_signature(ExternalName::user(0, 0), sig);
+//! let mut sig = Signature::new(CallConv::SystemV);
+//! sig.returns.push(AbiParam::new(I32));
+//! sig.params.push(AbiParam::new(I32));
+//! let mut fn_builder_ctx = FunctionBuilderContext::new();
+//! let mut func = Function::with_name_signature(ExternalName::user(0, 0), sig);
+//! {
+//!     let mut builder = FunctionBuilder::new(&mut func, &mut fn_builder_ctx);
+//!
+//!     let block0 = builder.create_ebb();
+//!     let block1 = builder.create_ebb();
+//!     let block2 = builder.create_ebb();
+//!     let block3 = builder.create_ebb();
+//!     let x = Variable::new(0);
+//!     let y = Variable::new(1);
+//!     let z = Variable::new(2);
+//!     builder.declare_var(x, I32);
+//!     builder.declare_var(y, I32);
+//!     builder.declare_var(z, I32);
+//!     builder.append_ebb_params_for_function_params(block0);
+//!
+//!     builder.switch_to_block(block0);
+//!     builder.seal_block(block0);
 //!     {
-//!         let mut builder = FunctionBuilder::new(&mut func, &mut fn_builder_ctx);
+//!         let tmp = builder.ebb_params(block0)[0]; // the first function parameter
+//!         builder.def_var(x, tmp);
+//!     }
+//!     {
+//!         let tmp = builder.ins().iconst(I32, 2);
+//!         builder.def_var(y, tmp);
+//!     }
+//!     {
+//!         let arg1 = builder.use_var(x);
+//!         let arg2 = builder.use_var(y);
+//!         let tmp = builder.ins().iadd(arg1, arg2);
+//!         builder.def_var(z, tmp);
+//!     }
+//!     builder.ins().jump(block1, &[]);
 //!
-//!         let block0 = builder.create_ebb();
-//!         let block1 = builder.create_ebb();
-//!         let block2 = builder.create_ebb();
-//!         let block3 = builder.create_ebb();
-//!         let x = Variable::new(0);
-//!         let y = Variable::new(1);
-//!         let z = Variable::new(2);
-//!         builder.declare_var(x, I32);
-//!         builder.declare_var(y, I32);
-//!         builder.declare_var(z, I32);
-//!         builder.append_ebb_params_for_function_params(block0);
+//!     builder.switch_to_block(block1);
+//!     {
+//!         let arg1 = builder.use_var(y);
+//!         let arg2 = builder.use_var(z);
+//!         let tmp = builder.ins().iadd(arg1, arg2);
+//!         builder.def_var(z, tmp);
+//!     }
+//!     {
+//!         let arg = builder.use_var(y);
+//!         builder.ins().brnz(arg, block3, &[]);
+//!     }
+//!     builder.ins().jump(block2, &[]);
 //!
-//!         builder.switch_to_block(block0);
-//!         builder.seal_block(block0);
-//!         {
-//!             let tmp = builder.ebb_params(block0)[0]; // the first function parameter
-//!             builder.def_var(x, tmp);
-//!         }
-//!         {
-//!             let tmp = builder.ins().iconst(I32, 2);
-//!             builder.def_var(y, tmp);
-//!         }
-//!         {
-//!             let arg1 = builder.use_var(x);
-//!             let arg2 = builder.use_var(y);
-//!             let tmp = builder.ins().iadd(arg1, arg2);
-//!             builder.def_var(z, tmp);
-//!         }
-//!         builder.ins().jump(block1, &[]);
-//!
-//!         builder.switch_to_block(block1);
-//!         {
-//!             let arg1 = builder.use_var(y);
-//!             let arg2 = builder.use_var(z);
-//!             let tmp = builder.ins().iadd(arg1, arg2);
-//!             builder.def_var(z, tmp);
-//!         }
-//!         {
-//!             let arg = builder.use_var(y);
-//!             builder.ins().brnz(arg, block3, &[]);
-//!         }
-//!         builder.ins().jump(block2, &[]);
-//!
-//!         builder.switch_to_block(block2);
-//!         builder.seal_block(block2);
-//!         {
-//!             let arg1 = builder.use_var(z);
-//!             let arg2 = builder.use_var(x);
-//!             let tmp = builder.ins().isub(arg1, arg2);
-//!             builder.def_var(z, tmp);
-//!         }
-//!         {
-//!             let arg = builder.use_var(y);
-//!             builder.ins().return_(&[arg]);
-//!         }
-//!
-//!         builder.switch_to_block(block3);
-//!         builder.seal_block(block3);
-//!
-//!         {
-//!             let arg1 = builder.use_var(y);
-//!             let arg2 = builder.use_var(x);
-//!             let tmp = builder.ins().isub(arg1, arg2);
-//!             builder.def_var(y, tmp);
-//!         }
-//!         builder.ins().jump(block1, &[]);
-//!         builder.seal_block(block1);
-//!
-//!         builder.finalize();
+//!     builder.switch_to_block(block2);
+//!     builder.seal_block(block2);
+//!     {
+//!         let arg1 = builder.use_var(z);
+//!         let arg2 = builder.use_var(x);
+//!         let tmp = builder.ins().isub(arg1, arg2);
+//!         builder.def_var(z, tmp);
+//!     }
+//!     {
+//!         let arg = builder.use_var(y);
+//!         builder.ins().return_(&[arg]);
 //!     }
 //!
-//!     let flags = settings::Flags::new(settings::builder());
-//!     let res = verify_function(&func, &flags);
-//!     println!("{}", func.display(None));
-//!     if let Err(errors) = res {
-//!         panic!("{}", errors);
+//!     builder.switch_to_block(block3);
+//!     builder.seal_block(block3);
+//!
+//!     {
+//!         let arg1 = builder.use_var(y);
+//!         let arg2 = builder.use_var(x);
+//!         let tmp = builder.ins().isub(arg1, arg2);
+//!         builder.def_var(y, tmp);
 //!     }
+//!     builder.ins().jump(block1, &[]);
+//!     builder.seal_block(block1);
+//!
+//!     builder.finalize();
+//! }
+//!
+//! let flags = settings::Flags::new(settings::builder());
+//! let res = verify_function(&func, &flags);
+//! println!("{}", func.display(None));
+//! if let Err(errors) = res {
+//!     panic!("{}", errors);
 //! }
 //! ```
 


### PR DESCRIPTION
- [x] This has been discussed in issue #1170
- [x] A short description of what this does, why it is needed: this fixes the remaining clippy warnings that I could see from running `cargo clean && cargo clippy` (is there a better way to do this?)
- [x] This PR contains no test cases; no functionality should change
- [x] A reviewer from the core maintainer team has been assigned for this PR