### PR TITLE
Fix narrow_icmp_imm

### DIFF
--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -702,7 +702,7 @@ fn narrow_icmp_imm(
 
     let imm_low = pos
         .ins()
-        .iconst(ty_half, imm & (1u128 << (ty_half.bits() - 1)) as i64);
+        .iconst(ty_half, imm & ((1u128 << ty_half.bits()) - 1) as i64);
     let imm_high = pos
         .ins()
         .iconst(ty_half, imm.wrapping_shr(ty_half.bits().into()));

--- a/filetests/isa/riscv/legalize-icmp_imm-i64.clif
+++ b/filetests/isa/riscv/legalize-icmp_imm-i64.clif
@@ -1,0 +1,55 @@
+test legalizer
+target riscv32
+
+; regex: V=v\d+
+
+function %icmp_imm_eq(i64) -> b1 {
+ebb0(v0: i64):
+    v1 = icmp_imm eq v0, 0x20202020_10101010
+    return v1
+}
+; check: ebb0($(v0l=$V): i32, $(v0h=$V): i32, $(link=$V): i32):
+; nextln: $(v2l=$V) -> $(v0l)
+; nextln: $(v2h=$V) -> $(v0h)
+; nextln: v0 = iconcat $(v0l), $(v0h)
+; nextln: $(imm_low=$V) = iconst.i32 0x1010_1010
+; nextln: $(imm_high=$V) = iconst.i32 0x2020_2020
+; nextln: $(v3=$V) = icmp eq $(v2l), $(imm_low)
+; nextln: $(v4=$V) = icmp eq $(v2h), $(imm_high)
+; nextln: v1 = band $(v3), $(v4)
+; nextln: return v1, $(link)
+
+function %icmp_imm_ne(i64) -> b1 {
+ebb0(v0: i64):
+    v1 = icmp_imm ne v0, 0x33333333_44444444
+    return v1
+}
+; check: ebb0($(v0l=$V): i32, $(v0h=$V): i32, $(link=$V): i32):
+; nextln: $(v2l=$V) -> $(v0l)
+; nextln: $(v2h=$V) -> $(v0h)
+; nextln: v0 = iconcat $(v0l), $(v0h)
+; nextln: $(imm_low=$V) = iconst.i32 0x4444_4444
+; nextln: $(imm_high=$V) = iconst.i32 0x3333_3333
+; nextln: $(v3=$V) = icmp ne $(v2l), $(imm_low)
+; nextln: $(v4=$V) = icmp ne $(v2h), $(imm_high)
+; nextln: v1 = bor $(v3), $(v4)
+; nextln: return v1, $(link)
+
+function %icmp_imm_sge(i64) -> b1 {
+ebb0(v0: i64):
+    v1 = icmp_imm sge v0, 0x01020304_05060708
+    return v1
+}
+; check: ebb0($(v0l=$V): i32, $(v0h=$V): i32, $(link=$V): i32):
+; nextln: $(v2l=$V) -> $(v0l)
+; nextln: $(v2h=$V) -> $(v0h)
+; nextln: v0 = iconcat $(v0l), $(v0h)
+; nextln: $(imm_low=$V) = iconst.i32 0x0506_0708
+; nextln: $(imm_high=$V) = iconst.i32 0x0102_0304
+; nextln: $(v3=$V) = icmp sgt $(v2h), $(imm_high)
+; nextln: $(v4=$V) = icmp slt $(v2h), $(imm_high)
+; nextln: $(v5=$V) = icmp uge $(v2l), $(imm_low)
+; nextln: $(v6=$V) = bnot $v4
+; nextln: $(v7=$V) = band $v6, $v5
+; nextln: v1 = bor $(v3), $(v7)
+; nextln: return v1, $(link)


### PR DESCRIPTION
- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
This is a really small change.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
This fixes small bug caused by inaccurate use of parentheses in `narrow_icmp_imm`.
- [ ] This PR contains test cases, if meaningful.
No tests.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.
@bnjbvr 
<!-- Please ensure all communication adheres to the [code of
conduct](https://github.com/CraneStation/cranelift/blob/master/CODE_OF_CONDUCT.md). -->
