### PR TITLE
Add 8x16 shift legalizations for x86 SIMD

### DIFF
--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -1529,6 +1529,8 @@ fn define_alu(
     e.enc_i32_i64(selectif, rec_cmov.opcodes(&CMOV_OVERFLOW));
 }
 
+// TODO re-factor this function to avoid this ignored rule:
+#[allow(clippy::cognitive_complexity)]
 #[inline(never)]
 fn define_simd(
     e: &mut PerCpuModeEncodings,

--- a/cranelift-codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift-codegen/meta/src/isa/x86/legalize.rs
@@ -76,7 +76,6 @@ pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &Instruct
     let x86_pminu = x86_instructions.by_name("x86_pminu");
     let x86_pshufb = x86_instructions.by_name("x86_pshufb");
     let x86_pshufd = x86_instructions.by_name("x86_pshufd");
-    let x86_psll = x86_instructions.by_name("x86_psll");
     let x86_psra = x86_instructions.by_name("x86_psra");
     let x86_psrl = x86_instructions.by_name("x86_psrl");
     let x86_ptest = x86_instructions.by_name("x86_ptest");
@@ -414,16 +413,6 @@ pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &Instruct
         );
     }
 
-    // SIMD shift left (logical)
-    for ty in &[I16, I32, I64] {
-        let ishl = ishl.bind(vector(*ty, sse_vector_size));
-        let bitcast = bitcast.bind(vector(I64, sse_vector_size));
-        narrow.legalize(
-            def!(a = ishl(x, y)),
-            vec![def!(b = bitcast(y)), def!(a = x86_psll(x, b))],
-        );
-    }
-
     // SIMD shift right (logical)
     for ty in &[I16, I32, I64] {
         let ushr = ushr.bind(vector(*ty, sse_vector_size));
@@ -610,6 +599,7 @@ pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &Instruct
     narrow.custom_legalize(extractlane, "convert_extractlane");
     narrow.custom_legalize(insertlane, "convert_insertlane");
     narrow.custom_legalize(ineg, "convert_ineg");
+    narrow.custom_legalize(ishl, "convert_ishl");
 
     narrow.build_and_add_to(&mut shared.transform_groups);
 }


### PR DESCRIPTION
- [x] This has not been discussed in an issue.
- [x] A short description of what this does, why it is needed: I did not implement the `i8x16` shifts previously because there was discussion about whether they should be included in the spec (https://github.com/WebAssembly/simd/issues/117). I still feel they should not be included due to the large overhead they impose on x86 but I am (rather unwillingly) implementing them here so we can get additional performance measurements.
- [ ] This PR contains test cases, if meaningful.
- [x] A reviewer from the core maintainer team has been assigned for this PR.