### PR TITLE
add `entries()` API for Switch

### DIFF
--- a/cranelift-frontend/src/switch.rs
+++ b/cranelift-frontend/src/switch.rs
@@ -258,6 +258,14 @@ impl Switch {
     }
 }
 
+impl core::ops::Deref for Switch {
+    type Target = HashMap<EntryIndex, Ebb>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.cases
+    }
+}
+
 /// This represents a contiguous range of cases to switch on.
 ///
 /// For example 10 => ebb1, 11 => ebb2, 12 => ebb7 will be represented as:

--- a/cranelift-frontend/src/switch.rs
+++ b/cranelift-frontend/src/switch.rs
@@ -62,6 +62,11 @@ impl Switch {
         );
     }
 
+    /// Get a reference to all existing entries
+    pub fn entries(&self) -> &HashMap<EntryIndex, Ebb> {
+        &self.cases
+    }
+
     /// Turn the `cases` `HashMap` into a list of `ContiguousCaseRange`s.
     ///
     /// # Postconditions
@@ -255,14 +260,6 @@ impl Switch {
         let contiguous_case_ranges = self.collect_contiguous_case_ranges();
         let cases_and_jt_ebbs = Self::build_search_tree(bx, val, otherwise, contiguous_case_ranges);
         Self::build_jump_tables(bx, val, otherwise, cases_and_jt_ebbs);
-    }
-}
-
-impl core::ops::Deref for Switch {
-    type Target = HashMap<EntryIndex, Ebb>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.cases
     }
 }
 


### PR DESCRIPTION
- [x] This has been discussed in issue #1357
- [x] A short description of what this does, why it is needed;

This allows library users to see what entries already exist in a switch.

- [ ] This PR contains test cases, if meaningful.

N/A

- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.

I am not sure who should review this PR. r? @bnjbvr