### PR TITLE
Wasm: Typed select and nullref translation

### DIFF
--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -132,6 +132,13 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let (arg1, arg2, cond) = state.pop3();
             state.push1(builder.ins().select(cond, arg1, arg2));
         }
+        Operator::TypedSelect { ty: _ } => {
+            // We ignore the explicit type parameter as it is only needed for
+            // validation, which we require to have been performed before
+            // translation.
+            let (arg1, arg2, cond) = state.pop3();
+            state.push1(builder.ins().select(cond, arg1, arg2));
+        }
         Operator::Nop => {
             // We do nothing
         }
@@ -967,9 +974,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         Operator::F32Lt | Operator::F64Lt => translate_fcmp(FloatCC::LessThan, builder, state),
         Operator::F32Le | Operator::F64Le => {
             translate_fcmp(FloatCC::LessThanOrEqual, builder, state)
-        }
-        Operator::TypedSelect { .. } => {
-            return Err(wasm_unsupported!("proposed typed select operator {:?}", op))
         }
         Operator::RefNull => state.push1(builder.ins().null(environ.reference_type())),
         Operator::RefIsNull => {

--- a/cranelift-wasm/src/func_translator.rs
+++ b/cranelift-wasm/src/func_translator.rs
@@ -196,6 +196,7 @@ fn declare_locals<FE: FuncEnvironment + ?Sized>(
             let constant_handle = builder.func.dfg.constants.insert([0; 16].to_vec().into());
             builder.ins().vconst(ir::types::I8X16, constant_handle)
         }
+        NullRef => builder.ins().null(environ.reference_type()),
         AnyRef => builder.ins().null(environ.reference_type()),
         AnyFunc => builder.ins().null(environ.reference_type()),
         ty => return Err(wasm_unsupported!("unsupported local type {:?}", ty)),

--- a/cranelift-wasm/src/translation_utils.rs
+++ b/cranelift-wasm/src/translation_utils.rs
@@ -131,7 +131,9 @@ pub fn type_to_type<PE: TargetEnvironment + ?Sized>(
         wasmparser::Type::F32 => Ok(ir::types::F32),
         wasmparser::Type::F64 => Ok(ir::types::F64),
         wasmparser::Type::V128 => Ok(ir::types::I8X16),
-        wasmparser::Type::AnyRef | wasmparser::Type::AnyFunc => Ok(environ.reference_type()),
+        wasmparser::Type::AnyRef | wasmparser::Type::AnyFunc | wasmparser::Type::NullRef => {
+            Ok(environ.reference_type())
+        }
         ty => Err(wasm_unsupported!("type_to_type: wasm type {:?}", ty)),
     }
 }
@@ -171,6 +173,7 @@ pub fn blocktype_params_results(
             wasmparser::Type::V128 => (&[], &[wasmparser::Type::V128]),
             wasmparser::Type::AnyRef => (&[], &[wasmparser::Type::AnyRef]),
             wasmparser::Type::AnyFunc => (&[], &[wasmparser::Type::AnyFunc]),
+            wasmparser::Type::NullRef => (&[], &[wasmparser::Type::NullRef]),
             wasmparser::Type::EmptyBlockType => (&[], &[]),
             ty => return Err(wasm_unsupported!("blocktype_params_results: type {:?}", ty)),
         },
@@ -203,7 +206,7 @@ pub fn ebb_with_params<PE: TargetEnvironment + ?Sized>(
             wasmparser::Type::F64 => {
                 builder.append_ebb_param(ebb, ir::types::F64);
             }
-            wasmparser::Type::AnyRef | wasmparser::Type::AnyFunc => {
+            wasmparser::Type::AnyRef | wasmparser::Type::AnyFunc | wasmparser::Type::NullRef => {
                 builder.append_ebb_param(ebb, environ.reference_type());
             }
             wasmparser::Type::V128 => {

--- a/wasmtests/nullref.wat
+++ b/wasmtests/nullref.wat
@@ -1,0 +1,11 @@
+(module
+	(func (result nullref)
+		ref.null
+	)
+
+	(func (result nullref)
+		(block (result nullref)
+			ref.null
+		)
+	)
+)

--- a/wasmtests/select.wat
+++ b/wasmtests/select.wat
@@ -1,0 +1,19 @@
+(module
+  (func $untyped-select (result i32)
+  	i32.const 42
+  	i32.const 24
+  	i32.const 1
+  	select)
+
+  (func $typed-select-1 (result anyref)
+  	ref.null
+  	ref.null
+  	i32.const 1
+  	select (result anyref))
+
+  (func $typed-select-2 (param anyref) (result anyref)
+    ref.null
+    local.get 0
+    i32.const 1
+    select (result anyref))
+)


### PR DESCRIPTION
The reftypes proposal has introduced a typed select instruction to ensure efficient validation in the future with complex subtyping relationships. In addition, a proper 'nullref' type has been added. Both of these changes are supported in `wasmparser` but there are some additional updates needed to `cranelift-wasm`.