### PR TITLE
Add initial support for EVEX encodings

### DIFF
--- a/cranelift-codegen/meta/src/cdsl/regs.rs
+++ b/cranelift-codegen/meta/src/cdsl/regs.rs
@@ -57,12 +57,12 @@ impl RegBank {
                 // Ultimate try: try to parse a number and use this in the array, eg r15 on x86.
                 if let Ok(as_num) = name_without_prefix.parse::<u8>() {
                     assert!(
-                        (as_num - self.first_unit) < self.units,
+                        as_num < self.units,
                         "trying to get {}, but bank only has {} registers!",
                         name,
                         self.units
                     );
-                    (as_num - self.first_unit) as usize
+                    as_num as usize
                 } else {
                     panic!("invalid register name {}", name);
                 }

--- a/cranelift-codegen/meta/src/gen_registers.rs
+++ b/cranelift-codegen/meta/src/gen_registers.rs
@@ -57,7 +57,13 @@ fn gen_regclass(isa: &TargetIsa, reg_class: &RegClass, fmt: &mut Formatter) {
         fmtln!(fmt, "first: {},", reg_bank.first_unit + reg_class.start);
         fmtln!(fmt, "subclasses: {:#x},", reg_class.subclass_mask());
         fmtln!(fmt, "mask: [{}],", mask);
-        fmtln!(fmt, "pinned_reg: {:?},", reg_bank.pinned_reg);
+        fmtln!(
+            fmt,
+            "pinned_reg: {:?},",
+            reg_bank
+                .pinned_reg
+                .map(|index| index + reg_bank.first_unit as u16 + reg_class.start as u16)
+        );
         fmtln!(fmt, "info: &INFO,");
     });
     fmtln!(fmt, "};");

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -1611,6 +1611,7 @@ fn define_simd(
     let x86_ptest = x86.by_name("x86_ptest");
 
     // Shorthands for recipes.
+    let rec_evex_reg_vvvv_rm_128 = r.template("evex_reg_vvvv_rm_128");
     let rec_f_ib = r.template("f_ib");
     let rec_fa = r.template("fa");
     let rec_fa_ib = r.template("fa_ib");
@@ -1646,6 +1647,7 @@ fn define_simd(
     let use_ssse3_simd = settings.predicate_by_name("use_ssse3_simd");
     let use_sse41_simd = settings.predicate_by_name("use_sse41_simd");
     let use_sse42_simd = settings.predicate_by_name("use_sse42_simd");
+    let use_avx512dq_simd = settings.predicate_by_name("use_avx512dq_simd");
 
     // SIMD vector size: eventually multiple vector sizes may be supported but for now only
     // SSE-sized vectors are available.
@@ -1918,6 +1920,16 @@ fn define_simd(
     ] {
         let imul = imul.bind(vector(*ty, sse_vector_size));
         e.enc_32_64_maybe_isap(imul, rec_fa.opcodes(opcodes), *isap);
+    }
+
+    // SIMD integer multiplication for I64x2 using a AVX512.
+    {
+        let imul = imul.bind(vector(I64, sse_vector_size));
+        e.enc_32_64_maybe_isap(
+            imul,
+            rec_evex_reg_vvvv_rm_128.opcodes(&PMULLQ).w(),
+            Some(use_avx512dq_simd), // TODO need an OR predicate to join with AVX512VL
+        );
     }
 
     // SIMD logical operations

--- a/cranelift-codegen/meta/src/isa/x86/opcodes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/opcodes.rs
@@ -415,6 +415,10 @@ pub static PMULLW: [u8; 3] = [0x66, 0x0f, 0xd5];
 /// bits of each product in xmm1 (SSE4.1).
 pub static PMULLD: [u8; 4] = [0x66, 0x0f, 0x38, 0x40];
 
+/// Multiply the packed quadword signed integers in xmm2 and xmm3/m128 and store the low 64
+/// bits of each product in xmm1 (AVX512VL/DQ). Requires an EVEX encoding.
+pub static PMULLQ: [u8; 4] = [0x66, 0x0f, 0x38, 0x40];
+
 /// Pop top of stack into r{16,32,64}; increment stack pointer.
 pub static POP_REG: [u8; 1] = [0x58];
 

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -132,6 +132,26 @@ fn replace_nonrex_constraints(
         .collect()
 }
 
+fn replace_evex_constraints(
+    regs: &IsaRegs,
+    constraints: Vec<OperandConstraint>,
+) -> Vec<OperandConstraint> {
+    constraints
+        .into_iter()
+        .map(|constraint| match constraint {
+            OperandConstraint::RegClass(rc_index) => {
+                let new_rc_index = if rc_index == regs.class_by_name("FPR") {
+                    regs.class_by_name("FPR32")
+                } else {
+                    rc_index
+                };
+                OperandConstraint::RegClass(new_rc_index)
+            }
+            _ => constraint,
+        })
+        .collect()
+}
+
 /// Specifies how the REX prefix is emitted by a Recipe.
 #[derive(Copy, Clone, PartialEq)]
 pub enum RexRecipeKind {
@@ -151,6 +171,9 @@ pub enum RexRecipeKind {
     /// Because such a Recipe has a non-constant instruction size, it must have
     /// a special `compute_size` handler for the inferrable-REX case.
     InferRex,
+
+    /// The Recipe must hardcode the emission of an EVEX prefix.
+    Evex,
 }
 
 impl Default for RexRecipeKind {
@@ -284,11 +307,21 @@ impl<'builder> Template<'builder> {
         copy.rex_kind = RexRecipeKind::InferRex;
         copy
     }
+    pub fn evex(&self) -> Self {
+        assert!(
+            self.rex_kind == RexRecipeKind::Unspecified,
+            "Template prefix must be unspecified to change to EVEX."
+        );
+        Self {
+            rex_kind: RexRecipeKind::Evex,
+            ..self.clone()
+        }
+    }
 
     pub fn build(mut self) -> (EncodingRecipe, u16) {
         let (opcode, bits) = decode_opcodes(&self.op_bytes, self.rrr_bits, self.w_bit);
 
-        let (recipe_name, rex_prefix_size) = match self.rex_kind {
+        let (recipe_name, size_addendum) = match self.rex_kind {
             RexRecipeKind::Unspecified | RexRecipeKind::NeverEmitRex => {
                 // Ensure the operands are limited to non-REX constraints.
                 let operands_in = self.recipe.operands_in.unwrap_or_default();
@@ -297,9 +330,11 @@ impl<'builder> Template<'builder> {
                 self.recipe.operands_out =
                     Some(replace_nonrex_constraints(self.regs, operands_out));
 
-                (opcode.into(), 0)
+                (opcode.into(), self.op_bytes.len() as u64)
             }
-            RexRecipeKind::AlwaysEmitRex => ("Rex".to_string() + opcode, 1),
+            RexRecipeKind::AlwaysEmitRex => {
+                ("Rex".to_string() + opcode, self.op_bytes.len() as u64 + 1)
+            }
             RexRecipeKind::InferRex => {
                 // Hook up the right function for inferred compute_size().
                 assert!(
@@ -309,11 +344,19 @@ impl<'builder> Template<'builder> {
                 );
                 self.recipe.compute_size = self.inferred_rex_compute_size;
 
-                ("DynRex".to_string() + opcode, 0)
+                ("DynRex".to_string() + opcode, self.op_bytes.len() as u64)
+            }
+            RexRecipeKind::Evex => {
+                // Allow the operands to expand limits to EVEX constraints.
+                let operands_in = self.recipe.operands_in.unwrap_or_default();
+                self.recipe.operands_in = Some(replace_evex_constraints(self.regs, operands_in));
+                let operands_out = self.recipe.operands_out.unwrap_or_default();
+                self.recipe.operands_out = Some(replace_evex_constraints(self.regs, operands_out));
+
+                ("Evex".to_string() + opcode, 4 + 1)
             }
         };
 
-        let size_addendum = self.op_bytes.len() as u64 + rex_prefix_size;
         self.recipe.base_size += size_addendum;
 
         // Branch ranges are relative to the end of the instruction.
@@ -376,6 +419,7 @@ pub(crate) fn define<'shared>(
     let abcd = regs.class_by_name("ABCD");
     let gpr = regs.class_by_name("GPR");
     let fpr = regs.class_by_name("FPR");
+    let fpr32 = regs.class_by_name("FPR32");
     let flag = regs.class_by_name("FLAG");
 
     // Operand constraints shorthands.
@@ -3248,6 +3292,24 @@ pub(crate) fn define<'shared>(
             sink.add_stackmap(args, func, isa);
         "#,
         ),
+    );
+
+    recipes.add_template(
+        Template::new(
+        EncodingRecipeBuilder::new("evex_reg_vvvv_rm_128", &formats.binary, 1)
+            .operands_in(vec![fpr32, fpr32])
+            .operands_out(vec![fpr32])
+            .emit(
+                r#"
+                // instruction encoding operands: reg (op1, w), vvvv (op2, r), rm (op3, r)
+                // this maps to:                  out_reg0,     in_reg0,       in_reg1
+                let context = EvexContext::Other { length: EvexVectorLength::V128 };
+                let masking = EvexMasking::None;
+                put_evex(bits, out_reg0, in_reg0, in_reg1, context, masking, sink); // params: reg, vvvv, rm
+                modrm_rr(in_reg1, out_reg0, sink); // params: rm, reg
+                "#,
+            ),
+        regs).rex_kind(RexRecipeKind::Evex)
     );
 
     recipes

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -152,9 +152,9 @@ fn replace_evex_constraints(
         .collect()
 }
 
-/// Specifies how the REX prefix is emitted by a Recipe.
+/// Specifies how the prefix (e.g. REX) is emitted by a Recipe.
 #[derive(Copy, Clone, PartialEq)]
-pub enum RexRecipeKind {
+pub enum RecipePrefixKind {
     /// The REX emission behavior is not hardcoded for the Recipe
     /// and may be overridden when using the Template.
     Unspecified,
@@ -176,7 +176,7 @@ pub enum RexRecipeKind {
     Evex,
 }
 
-impl Default for RexRecipeKind {
+impl Default for RecipePrefixKind {
     fn default() -> Self {
         Self::Unspecified
     }
@@ -196,7 +196,7 @@ pub(crate) struct Template<'builder> {
     recipe: EncodingRecipeBuilder,
 
     /// How is the REX prefix emitted?
-    rex_kind: RexRecipeKind,
+    rex_kind: RecipePrefixKind,
 
     /// Function for `compute_size()` when REX is inferrable.
     inferred_rex_compute_size: Option<&'static str>,
@@ -218,7 +218,7 @@ impl<'builder> Template<'builder> {
         Self {
             regs,
             recipe,
-            rex_kind: RexRecipeKind::default(),
+            rex_kind: RecipePrefixKind::default(),
             inferred_rex_compute_size: None,
             when_prefixed: None,
             w_bit: 0,
@@ -230,7 +230,7 @@ impl<'builder> Template<'builder> {
     fn name(&self) -> &str {
         &self.recipe.name
     }
-    fn rex_kind(self, kind: RexRecipeKind) -> Self {
+    fn rex_kind(self, kind: RecipePrefixKind) -> Self {
         Self {
             rex_kind: kind,
             ..self
@@ -270,16 +270,16 @@ impl<'builder> Template<'builder> {
     }
     pub fn nonrex(&self) -> Self {
         assert!(
-            self.rex_kind != RexRecipeKind::AlwaysEmitRex,
+            self.rex_kind != RecipePrefixKind::AlwaysEmitRex,
             "Template requires REX prefix."
         );
         let mut copy = self.clone();
-        copy.rex_kind = RexRecipeKind::NeverEmitRex;
+        copy.rex_kind = RecipePrefixKind::NeverEmitRex;
         copy
     }
     pub fn rex(&self) -> Self {
         assert!(
-            self.rex_kind != RexRecipeKind::NeverEmitRex,
+            self.rex_kind != RecipePrefixKind::NeverEmitRex,
             "Template requires no REX prefix."
         );
         if let Some(prefixed) = &self.when_prefixed {
@@ -291,12 +291,12 @@ impl<'builder> Template<'builder> {
             return ret;
         }
         let mut copy = self.clone();
-        copy.rex_kind = RexRecipeKind::AlwaysEmitRex;
+        copy.rex_kind = RecipePrefixKind::AlwaysEmitRex;
         copy
     }
     pub fn infer_rex(&self) -> Self {
         assert!(
-            self.rex_kind != RexRecipeKind::NeverEmitRex,
+            self.rex_kind != RecipePrefixKind::NeverEmitRex,
             "Template requires no REX prefix."
         );
         assert!(
@@ -304,16 +304,16 @@ impl<'builder> Template<'builder> {
             "infer_rex used with when_prefixed()."
         );
         let mut copy = self.clone();
-        copy.rex_kind = RexRecipeKind::InferRex;
+        copy.rex_kind = RecipePrefixKind::InferRex;
         copy
     }
     pub fn evex(&self) -> Self {
         assert!(
-            self.rex_kind == RexRecipeKind::Unspecified,
+            self.rex_kind == RecipePrefixKind::Unspecified,
             "Template prefix must be unspecified to change to EVEX."
         );
         Self {
-            rex_kind: RexRecipeKind::Evex,
+            rex_kind: RecipePrefixKind::Evex,
             ..self.clone()
         }
     }
@@ -322,7 +322,7 @@ impl<'builder> Template<'builder> {
         let (opcode, bits) = decode_opcodes(&self.op_bytes, self.rrr_bits, self.w_bit);
 
         let (recipe_name, size_addendum) = match self.rex_kind {
-            RexRecipeKind::Unspecified | RexRecipeKind::NeverEmitRex => {
+            RecipePrefixKind::Unspecified | RecipePrefixKind::NeverEmitRex => {
                 // Ensure the operands are limited to non-REX constraints.
                 let operands_in = self.recipe.operands_in.unwrap_or_default();
                 self.recipe.operands_in = Some(replace_nonrex_constraints(self.regs, operands_in));
@@ -332,10 +332,10 @@ impl<'builder> Template<'builder> {
 
                 (opcode.into(), self.op_bytes.len() as u64)
             }
-            RexRecipeKind::AlwaysEmitRex => {
+            RecipePrefixKind::AlwaysEmitRex => {
                 ("Rex".to_string() + opcode, self.op_bytes.len() as u64 + 1)
             }
-            RexRecipeKind::InferRex => {
+            RecipePrefixKind::InferRex => {
                 // Hook up the right function for inferred compute_size().
                 assert!(
                     self.inferred_rex_compute_size.is_some(),
@@ -346,7 +346,7 @@ impl<'builder> Template<'builder> {
 
                 ("DynRex".to_string() + opcode, self.op_bytes.len() as u64)
             }
-            RexRecipeKind::Evex => {
+            RecipePrefixKind::Evex => {
                 // Allow the operands to expand limits to EVEX constraints.
                 let operands_in = self.recipe.operands_in.unwrap_or_default();
                 self.recipe.operands_in = Some(replace_evex_constraints(self.regs, operands_in));
@@ -2622,7 +2622,7 @@ pub(crate) fn define<'shared>(
                 ),
             regs,
         )
-        .rex_kind(RexRecipeKind::AlwaysEmitRex),
+        .rex_kind(RecipePrefixKind::AlwaysEmitRex),
     );
 
     recipes.add_template(
@@ -2656,7 +2656,7 @@ pub(crate) fn define<'shared>(
                 ),
             regs,
         )
-        .rex_kind(RexRecipeKind::AlwaysEmitRex),
+        .rex_kind(RecipePrefixKind::AlwaysEmitRex),
     );
 
     recipes.add_template(
@@ -2957,7 +2957,7 @@ pub(crate) fn define<'shared>(
                 ),
             regs,
         )
-        .rex_kind(RexRecipeKind::AlwaysEmitRex),
+        .rex_kind(RecipePrefixKind::AlwaysEmitRex),
     );
 
     recipes.add_template(
@@ -2998,7 +2998,7 @@ pub(crate) fn define<'shared>(
                 ),
             regs,
         )
-        .rex_kind(RexRecipeKind::AlwaysEmitRex),
+        .rex_kind(RecipePrefixKind::AlwaysEmitRex),
     );
 
     recipes.add_template(
@@ -3309,7 +3309,7 @@ pub(crate) fn define<'shared>(
                 modrm_rr(in_reg1, out_reg0, sink); // params: rm, reg
                 "#,
             ),
-        regs).rex_kind(RexRecipeKind::Evex)
+        regs).rex_kind(RecipePrefixKind::Evex)
     );
 
     recipes

--- a/cranelift-codegen/meta/src/isa/x86/registers.rs
+++ b/cranelift-codegen/meta/src/isa/x86/registers.rs
@@ -3,17 +3,17 @@ use crate::cdsl::regs::{IsaRegs, IsaRegsBuilder, RegBankBuilder, RegClassBuilder
 pub(crate) fn define() -> IsaRegs {
     let mut regs = IsaRegsBuilder::new();
 
+    let builder = RegBankBuilder::new("FloatRegs", "xmm")
+        .units(32)
+        .track_pressure(true);
+    let float_regs = regs.add_bank(builder);
+
     let builder = RegBankBuilder::new("IntRegs", "r")
         .units(16)
         .names(vec!["rax", "rcx", "rdx", "rbx", "rsp", "rbp", "rsi", "rdi"])
         .track_pressure(true)
         .pinned_reg(15);
     let int_regs = regs.add_bank(builder);
-
-    let builder = RegBankBuilder::new("FloatRegs", "xmm")
-        .units(16)
-        .track_pressure(true);
-    let float_regs = regs.add_bank(builder);
 
     let builder = RegBankBuilder::new("FlagRegs", "")
         .units(1)
@@ -24,7 +24,10 @@ pub(crate) fn define() -> IsaRegs {
     let builder = RegClassBuilder::new_toplevel("GPR", int_regs);
     let gpr = regs.add_class(builder);
 
-    let builder = RegClassBuilder::new_toplevel("FPR", float_regs);
+    let builder = RegClassBuilder::new_toplevel("FPR32", float_regs);
+    let fpr32 = regs.add_class(builder);
+
+    let builder = RegClassBuilder::subclass_of("FPR", fpr32, 0, 16);
     let fpr = regs.add_class(builder);
 
     let builder = RegClassBuilder::new_toplevel("FLAG", flag_reg);

--- a/cranelift-codegen/meta/src/isa/x86/settings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/settings.rs
@@ -8,8 +8,19 @@ pub(crate) fn define(shared: &SettingGroup) -> SettingGroup {
     let has_ssse3 = settings.add_bool("has_ssse3", "SSSE3: CPUID.01H:ECX.SSSE3[bit 9]", false);
     let has_sse41 = settings.add_bool("has_sse41", "SSE4.1: CPUID.01H:ECX.SSE4_1[bit 19]", false);
     let has_sse42 = settings.add_bool("has_sse42", "SSE4.2: CPUID.01H:ECX.SSE4_2[bit 20]", false);
+    let has_avx = settings.add_bool("has_avx", "AVX: CPUID.01H:ECX.AVX[bit 28]", false);
+    let has_avx2 = settings.add_bool("has_avx2", "AVX2: CPUID.07H:EBX.AVX2[bit 5]", false);
+    let has_avx512dq = settings.add_bool(
+        "has_avx512dq",
+        "AVX512DQ: CPUID.07H:EBX.AVX512DQ[bit 17]",
+        false,
+    );
+    let has_avx512vl = settings.add_bool(
+        "has_avx512vl",
+        "AVX512DQ: CPUID.07H:EBX.AVX512VL[bit 31]",
+        false,
+    );
     let has_popcnt = settings.add_bool("has_popcnt", "POPCNT: CPUID.01H:ECX.POPCNT[bit 23]", false);
-    settings.add_bool("has_avx", "AVX: CPUID.01H:ECX.AVX[bit 28]", false);
 
     // CPUID.(EAX=07H, ECX=0H):EBX
     let has_bmi1 = settings.add_bool(
@@ -47,6 +58,17 @@ pub(crate) fn define(shared: &SettingGroup) -> SettingGroup {
     settings.add_predicate(
         "use_sse42_simd",
         predicate!(shared_enable_simd && has_sse41 && has_sse42),
+    );
+
+    settings.add_predicate("use_avx_simd", predicate!(shared_enable_simd && has_avx));
+    settings.add_predicate("use_avx2_simd", predicate!(shared_enable_simd && has_avx2));
+    settings.add_predicate(
+        "use_avx512dq_simd",
+        predicate!(shared_enable_simd && has_avx512dq),
+    );
+    settings.add_predicate(
+        "use_avx512vl_simd",
+        predicate!(shared_enable_simd && has_avx512vl),
     );
 
     settings.add_predicate("use_popcnt", predicate!(has_popcnt && has_sse42));

--- a/cranelift-codegen/src/isa/registers.rs
+++ b/cranelift-codegen/src/isa/registers.rs
@@ -180,7 +180,7 @@ impl RegClassData {
     /// Returns true if `other` is a subclass of this register class.
     /// A register class is considered to be a subclass of itself.
     pub fn has_subclass<RCI: Into<RegClassIndex>>(&self, other: RCI) -> bool {
-        self.subclasses & (1 << other.into().0) != 0
+        self.subclasses & (1 << other.into().0) as u32 != 0
     }
 
     /// Get the top-level register class containing this class.
@@ -196,7 +196,7 @@ impl RegClassData {
 
     /// Does this register class contain `regunit`?
     pub fn contains(&self, regunit: RegUnit) -> bool {
-        self.mask[(regunit / 32) as usize] & (1u32 << (regunit % 32)) != 0
+        self.mask[(regunit / 32) as usize] & (1u32 << (regunit % 32) as u32) != 0
     }
 
     /// If the pinned register is used, is the given regunit the pinned register of this class?
@@ -206,6 +206,17 @@ impl RegClassData {
             && self
                 .pinned_reg
                 .map_or(false, |pinned_reg| pinned_reg == regunit)
+    }
+
+    /// Calculate the index of the register inside the class.
+    pub fn index_of(&self, regunit: RegUnit) -> u16 {
+        assert!(
+            self.contains(regunit),
+            "the {} register class does not contain {}",
+            self.name,
+            regunit
+        );
+        regunit - self.first
     }
 }
 

--- a/cranelift-codegen/src/isa/x86/binemit.rs
+++ b/cranelift-codegen/src/isa/x86/binemit.rs
@@ -61,6 +61,17 @@ fn rex3(rm: RegUnit, reg: RegUnit, index: RegUnit) -> u8 {
     BASE_REX | b | (x << 1) | (r << 2)
 }
 
+/// Encode the RXBR' bits of the EVEX P0 byte. For an explanation of these bits, see section 2.6.1
+/// in the Intel Software Development Manual, volume 2A. These bits can be used by different
+/// addressing modes (see section 2.6.2), requiring different `vex*` functions than this one.
+fn evex2(rm: RegUnit, reg: RegUnit) -> u8 {
+    let b = (!(rm >> 3) & 1) as u8;
+    let x = (!(rm >> 4) & 1) as u8;
+    let r = (!(reg >> 3) & 1) as u8;
+    let r_ = (!(reg >> 4) & 1) as u8;
+    0x00 | r_ | (b << 1) | (x << 2) | (r << 3)
+}
+
 /// Determines whether a REX prefix should be emitted.
 #[inline]
 fn needs_rex(bits: u16, rex: u8) -> bool {
@@ -204,6 +215,150 @@ fn put_rexmp3<CS: CodeSink + ?Sized>(bits: u16, rex: u8, sink: &mut CS) {
     sink.put1(0x0f);
     sink.put1(OP3_BYTE2[(enc.mm() - 2) as usize]);
     sink.put1(bits as u8);
+}
+
+/// Defines the EVEX context for the `L'`, `L`, and `b` bits (bits 6:4 of EVEX P2 byte). Table 2-36 in
+/// section 2.6.10 (Intel Software Development Manual, volume 2A) describes how these bits can be
+/// used together for certain classes of instructions; i.e., special should be taken to ensure
+/// that instructions use an applicable correct `EvexContext`. Table 2-39 contains cases where
+/// opcodes can result in an #UD.
+#[allow(dead_code)]
+enum EvexContext {
+    RoundingRegToRegFP {
+        rc: EvexRoundingControl,
+    },
+    NoRoundingFP {
+        sae: bool,
+        length: EvexVectorLength,
+    },
+    MemoryOp {
+        broadcast: bool,
+        length: EvexVectorLength,
+    },
+    Other {
+        length: EvexVectorLength,
+    },
+}
+
+impl EvexContext {
+    /// Encode the `L'`, `L`, and `b` bits (bits 6:4 of EVEX P2 byte) for merging with the P2 byte.
+    fn bits(&self) -> u8 {
+        match self {
+            Self::RoundingRegToRegFP { rc } => 0b001 | rc.bits() << 1,
+            Self::NoRoundingFP { sae, length } => (*sae as u8) | length.bits() << 1,
+            Self::MemoryOp { broadcast, length } => (*broadcast as u8) | length.bits() << 1,
+            Self::Other { length } => length.bits() << 1,
+        }
+    }
+}
+
+/// The EVEX format allows choosing a vector length in the `L'` and `L` bits; see `EvexContext`.
+enum EvexVectorLength {
+    V128,
+    V256,
+    V512,
+}
+
+impl EvexVectorLength {
+    /// Encode the `L'` and `L` bits for merging with the P2 byte.
+    fn bits(&self) -> u8 {
+        match self {
+            Self::V128 => 0b00,
+            Self::V256 => 0b01,
+            Self::V512 => 0b10,
+            // 0b11 is reserved (#UD).
+        }
+    }
+}
+
+/// The EVEX format allows defining rounding control in the `L'` and `L` bits; see `EvexContext`.
+enum EvexRoundingControl {
+    RNE,
+    RD,
+    RU,
+    RZ,
+}
+
+impl EvexRoundingControl {
+    /// Encode the `L'` and `L` bits for merging with the P2 byte.
+    fn bits(&self) -> u8 {
+        match self {
+            Self::RNE => 0b00,
+            Self::RD => 0b01,
+            Self::RU => 0b10,
+            Self::RZ => 0b11,
+        }
+    }
+}
+
+/// Defines the EVEX masking behavior; masking support is described in section 2.6.4 of the Intel
+/// Software Development Manual, volume 2A.
+#[allow(dead_code)]
+enum EvexMasking {
+    None,
+    Merging { k: u8 },
+    Zeroing { k: u8 },
+}
+
+impl EvexMasking {
+    /// Encode the `z` bit for merging with the P2 byte.
+    fn z_bit(&self) -> u8 {
+        match self {
+            Self::None | Self::Merging { .. } => 0,
+            Self::Zeroing { .. } => 1,
+        }
+    }
+
+    /// Encode the `aaa` bits for merging with the P2 byte.
+    fn aaa_bits(&self) -> u8 {
+        match self {
+            Self::None => 0b000,
+            Self::Merging { k } | Self::Zeroing { k } => {
+                debug_assert!(*k <= 7);
+                *k
+            }
+        }
+    }
+}
+
+/// Encode an EVEX prefix, including the instruction opcode. To match the current recipe
+/// convention, the ModR/M byte is written separately in the recipe. This EVEX encoding function
+/// only encodes the `reg` (operand 1), `vvvv` (operand 2), `rm` (operand 3) form; other forms are
+/// possible (see section 2.6.2, Intel Software Development Manual, volume 2A), requiring
+/// refactoring of this function or separate functions for each form (e.g. as for the REX prefix).
+fn put_evex<CS: CodeSink + ?Sized>(
+    bits: u16,
+    reg: RegUnit,
+    vvvvv: RegUnit,
+    rm: RegUnit,
+    context: EvexContext,
+    masking: EvexMasking,
+    sink: &mut CS,
+) {
+    let enc = EncodingBits::from(bits);
+
+    // EVEX prefix.
+    sink.put1(0x62);
+
+    let mut p0 = enc.mm() & 0b11;
+    p0 |= evex2(rm, reg) << 4; // bits 3:2 are always unset
+    sink.put1(p0);
+
+    let mut p1 = enc.pp() | 0b100; // bit 2 is always set
+    p1 |= (!(vvvvv as u8) & 0b1111) << 3;
+    p1 |= (enc.rex_w() & 0b1) << 7;
+    sink.put1(p1);
+
+    let mut p2 = masking.aaa_bits();
+    p2 |= (!(vvvvv as u8 >> 4) & 0b1) << 3;
+    p2 |= context.bits() << 4;
+    p2 |= masking.z_bit() << 7;
+    sink.put1(p2);
+
+    // Opcode
+    sink.put1(enc.opcode_byte());
+
+    // ModR/M byte placed in recipe
 }
 
 /// Emit a ModR/M byte for reg-reg operands.

--- a/cranelift-codegen/src/isa/x86/registers.rs
+++ b/cranelift-codegen/src/isa/x86/registers.rs
@@ -12,40 +12,61 @@ mod tests {
 
     #[test]
     fn unit_encodings() {
+        fn gpr(unit: usize) -> Option<u16> {
+            Some(GPR.unit(unit))
+        }
         // The encoding of integer registers is not alphabetical.
-        assert_eq!(INFO.parse_regunit("rax"), Some(0));
-        assert_eq!(INFO.parse_regunit("rbx"), Some(3));
-        assert_eq!(INFO.parse_regunit("rcx"), Some(1));
-        assert_eq!(INFO.parse_regunit("rdx"), Some(2));
-        assert_eq!(INFO.parse_regunit("rsi"), Some(6));
-        assert_eq!(INFO.parse_regunit("rdi"), Some(7));
-        assert_eq!(INFO.parse_regunit("rbp"), Some(5));
-        assert_eq!(INFO.parse_regunit("rsp"), Some(4));
-        assert_eq!(INFO.parse_regunit("r8"), Some(8));
-        assert_eq!(INFO.parse_regunit("r15"), Some(15));
+        assert_eq!(INFO.parse_regunit("rax"), gpr(0));
+        assert_eq!(INFO.parse_regunit("rbx"), gpr(3));
+        assert_eq!(INFO.parse_regunit("rcx"), gpr(1));
+        assert_eq!(INFO.parse_regunit("rdx"), gpr(2));
+        assert_eq!(INFO.parse_regunit("rsi"), gpr(6));
+        assert_eq!(INFO.parse_regunit("rdi"), gpr(7));
+        assert_eq!(INFO.parse_regunit("rbp"), gpr(5));
+        assert_eq!(INFO.parse_regunit("rsp"), gpr(4));
+        assert_eq!(INFO.parse_regunit("r8"), gpr(8));
+        assert_eq!(INFO.parse_regunit("r15"), gpr(15));
 
-        assert_eq!(INFO.parse_regunit("xmm0"), Some(16));
-        assert_eq!(INFO.parse_regunit("xmm15"), Some(31));
+        fn fpr(unit: usize) -> Option<u16> {
+            Some(FPR.unit(unit))
+        }
+        assert_eq!(INFO.parse_regunit("xmm0"), fpr(0));
+        assert_eq!(INFO.parse_regunit("xmm15"), fpr(15));
+
+        fn fpr32(unit: usize) -> Option<u16> {
+            Some(FPR32.unit(unit))
+        }
+        assert_eq!(INFO.parse_regunit("xmm0"), fpr32(0));
+        assert_eq!(INFO.parse_regunit("xmm31"), fpr32(31));
     }
 
     #[test]
     fn unit_names() {
-        fn uname(ru: RegUnit) -> String {
-            INFO.display_regunit(ru).to_string()
+        fn gpr(ru: RegUnit) -> String {
+            INFO.display_regunit(GPR.first + ru).to_string()
         }
+        assert_eq!(gpr(0), "%rax");
+        assert_eq!(gpr(3), "%rbx");
+        assert_eq!(gpr(1), "%rcx");
+        assert_eq!(gpr(2), "%rdx");
+        assert_eq!(gpr(6), "%rsi");
+        assert_eq!(gpr(7), "%rdi");
+        assert_eq!(gpr(5), "%rbp");
+        assert_eq!(gpr(4), "%rsp");
+        assert_eq!(gpr(8), "%r8");
+        assert_eq!(gpr(15), "%r15");
 
-        assert_eq!(uname(0), "%rax");
-        assert_eq!(uname(3), "%rbx");
-        assert_eq!(uname(1), "%rcx");
-        assert_eq!(uname(2), "%rdx");
-        assert_eq!(uname(6), "%rsi");
-        assert_eq!(uname(7), "%rdi");
-        assert_eq!(uname(5), "%rbp");
-        assert_eq!(uname(4), "%rsp");
-        assert_eq!(uname(8), "%r8");
-        assert_eq!(uname(15), "%r15");
-        assert_eq!(uname(16), "%xmm0");
-        assert_eq!(uname(31), "%xmm15");
+        fn fpr(ru: RegUnit) -> String {
+            INFO.display_regunit(FPR.first + ru).to_string()
+        }
+        assert_eq!(fpr(0), "%xmm0");
+        assert_eq!(fpr(15), "%xmm15");
+
+        fn fpr32(ru: RegUnit) -> String {
+            INFO.display_regunit(FPR32.first + ru).to_string()
+        }
+        assert_eq!(fpr32(0), "%xmm0");
+        assert_eq!(fpr32(31), "%xmm31");
     }
 
     #[test]

--- a/cranelift-codegen/src/isa/x86/unwind.rs
+++ b/cranelift-codegen/src/isa/x86/unwind.rs
@@ -1,6 +1,6 @@
 //! Unwind information for x64 Windows.
 
-use super::registers::RU;
+use super::registers::{GPR, RU};
 use crate::binemit::FrameUnwindSink;
 use crate::ir::{Function, InstructionData, Opcode};
 use crate::isa::{CallConv, RegUnit, TargetIsa};
@@ -54,7 +54,8 @@ impl UnwindCode {
                 write_u8(sink, *offset);
                 write_u8(
                     sink,
-                    ((*reg as u8) << 4) | (UnwindOperation::PushNonvolatileRegister as u8),
+                    ((GPR.index_of(*reg) as u8) << 4)
+                        | (UnwindOperation::PushNonvolatileRegister as u8),
                 );
             }
             Self::StackAlloc { offset, size } => {
@@ -262,7 +263,10 @@ impl UnwindInfo {
         write_u8(sink, node_count as u8);
 
         if let Some(reg) = self.frame_register {
-            write_u8(sink, (self.frame_register_offset << 4) | reg as u8);
+            write_u8(
+                sink,
+                (self.frame_register_offset << 4) | GPR.index_of(reg) as u8,
+            );
         } else {
             write_u8(sink, 0);
         }

--- a/cranelift-native/src/lib.rs
+++ b/cranelift-native/src/lib.rs
@@ -82,6 +82,15 @@ fn parse_x86_cpuid(isa_builder: &mut isa::Builder) -> Result<(), &'static str> {
         if info.has_bmi2() {
             isa_builder.enable("has_bmi2").unwrap();
         }
+        if info.has_avx2() {
+            isa_builder.enable("has_avx2").unwrap();
+        }
+        if info.has_avx512dq() {
+            isa_builder.enable("has_avx512dq").unwrap();
+        }
+        if info.has_avx512vl() {
+            isa_builder.enable("has_avx512vl").unwrap();
+        }
     }
     if let Some(info) = cpuid.get_extended_function_info() {
         if info.has_lzcnt() {

--- a/filetests/isa/x86/simd-avx512-arithmetic-binemit.clif
+++ b/filetests/isa/x86/simd-avx512-arithmetic-binemit.clif
@@ -1,0 +1,17 @@
+test binemit
+set enable_simd
+target x86_64 skylake has_avx512dq=true
+
+function %imul_i64x2() {
+block0:
+    [-, %xmm1]    v0 = vconst.i64x2 [1 2]
+    [-, %xmm2]    v1 = vconst.i64x2 [2 2]
+    [-, %xmm19]   v2 = imul v0, v1 ; bin: 62 e2 f5 08 40 da
+    ; 62, mandatory EVEX prefix
+    ; e2 = 1110 0010, R, X, B are unset (inverted) while R' is set (MSB in %xmm19); mm is set to 0F38
+    ; f5 = 1111 0101, W is set (64-bit op), vvvv set to 1 (inverted), bit 2 always set, pp set to 01
+    ; 08 = 0000 1000, everything, LL' indicates 128-bit, V' is unset (inverted, %xmm1 has MSB of 0)
+    ; 40, opcode (correct)
+    ; da = 1100 1010, ModR/M byte using 0b011 from %xmm19 in reg and 0b010 from %xmm2 in r/m
+    return
+}


### PR DESCRIPTION
- [x] This has been discussed in issue #1244.
- [x] A short description of what this does, why it is needed: since the Wasm SIMD spec has re-added instructions (e.g. `i64x2.mul`) that are optimally encoded in VEX/EVEX, it seems like we should support these encoding formats. For this PR, only EVEX was added (and not every addressing form) in order to implement i64x2 multiplication. I haven't yet test-run this on an AVX512DQ-compatible CPU but will soon; while implementing this, I discovered that there is no good way to indicate an encoding that is predicated on either of two settings flags (see TODO in `encodings.rs`).
- [x] This PR contains test cases, if meaningful.
- [x] A reviewer from the core maintainer team has been assigned for this PR (I'm tagging people that might be interested in this).