### PR TITLE
Add inline hints to some small functions

### DIFF
--- a/cranelift-codegen/src/ir/sourceloc.rs
+++ b/cranelift-codegen/src/ir/sourceloc.rs
@@ -20,22 +20,26 @@ pub struct SourceLoc(u32);
 
 impl SourceLoc {
     /// Create a new source location with the given bits.
+    #[inline]
     pub fn new(bits: u32) -> Self {
         Self(bits)
     }
 
     /// Is this the default source location?
+    #[inline]
     pub fn is_default(self) -> bool {
         self == Default::default()
     }
 
     /// Read the bits of this source location.
+    #[inline]
     pub fn bits(self) -> u32 {
         self.0
     }
 }
 
 impl Default for SourceLoc {
+    #[inline]
     fn default() -> Self {
         Self(!0)
     }


### PR DESCRIPTION
- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
  Before this PR, several short functions were not getting inlined into another crate, as they are neither generic, nor marked with an inline hint.
- [ ] This PR contains test cases, if meaningful. N/A
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.

Keeping this as draft until I have identified more functions that could benefit from this.

<!-- Please ensure all communication adheres to the [code of
conduct](https://github.com/CraneStation/cranelift/blob/master/CODE_OF_CONDUCT.md). -->
