### PR TITLE
add documentation mentions of cranelift-object where appropriate

### DIFF
--- a/cranelift-module/README.md
+++ b/cranelift-module/README.md
@@ -13,8 +13,11 @@ following `Backend` implementations:
 
  - `SimpleJITBackend`, provided by [cranelift-simplejit], which JITs
    code to memory for direct execution.
+ - `ObjectBackend`, provided by [cranelift-object], which emits native
+   object files.
  - `FaerieBackend`, provided by [cranelift-faerie], which emits native
    object files.
 
 [cranelift-simplejit]: https://crates.io/crates/cranelift-simplejit
+[cranelift-object]: https://crates.io/crates/cranelift-object
 [cranelift-faerie]: https://crates.io/crates/cranelift-faerie

--- a/cranelift-module/src/backend.rs
+++ b/cranelift-module/src/backend.rs
@@ -17,13 +17,16 @@ use std::string::String;
 
 /// A `Backend` implements the functionality needed to support a `Module`.
 ///
-/// Two notable implementations of this trait are:
+/// Three notable implementations of this trait are:
 ///  - `SimpleJITBackend`, defined in [cranelift-simplejit], which JITs
 ///    the contents of a `Module` to memory which can be directly executed.
+///  - `ObjectBackend`, defined in [cranelift-object], which writes the
+///    contents of a `Module` out as a native object file.
 ///  - `FaerieBackend`, defined in [cranelift-faerie], which writes the
 ///    contents of a `Module` out as a native object file.
 ///
 /// [cranelift-simplejit]: https://docs.rs/cranelift-simplejit/
+/// [cranelift-object]: https://docs.rs/cranelift-object/
 /// [cranelift-faerie]: https://docs.rs/cranelift-faerie/
 pub trait Backend
 where

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,11 @@ Rust Crate Documentation
     This crate manages compiling multiple functions and data objects
     together.
 
+`cranelift-object <https://docs.rs/cranelift-object/>`_
+    This crate provides a object-based backend for `cranelift-module`, which
+    emits native object files using the
+    `object <https://github.com/gimli-rs/object>`_ library.
+
 `cranelift-faerie <https://docs.rs/cranelift-faerie/>`_
     This crate provides a faerie-based backend for `cranelift-module`, which
     emits native object files using the


### PR DESCRIPTION
This change makes it slightly more obvious that `cranelift-object` can
be used in lieu of `cranelift-faerie`.

- [X] This has not been discussed in an issue.
- [X] A short description of what this does, why it is needed:

There are no mentions of `cranelift-object` in this documentation, and I was confused about what the difference was between `cranelift-object` and `cranelift-faerie`.  Ideally this PR makes things slightly less confusing; I would like to eliminate `cranelift-faerie` in a future PR.
- [X] This PR does not contain test cases, as it only modifies documentation.
- [X] A reviewer from the core maintainer team has been assigned for this PR.

<!-- Please ensure all communication adheres to the [code of
conduct](https://github.com/CraneStation/cranelift/blob/master/CODE_OF_CONDUCT.md). -->
