### PR TITLE
Preserve SIMD registers in Windows fastcall functions

### DIFF
--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -613,7 +613,7 @@ fn fastcall_prologue_epilogue(func: &mut ir::Function, isa: &dyn TargetIsa) -> C
         // the low 128 bits here, but we may find that in practice we should preserve all of
         // YMM6-15 (or even ZMM6-15?)
         let csr_arg =
-            ir::AbiParam::special_reg(types::F64X2, ir::ArgumentPurpose::CalleeSaved, fp_csr);
+            ir::AbiParam::special_reg(types::F64, ir::ArgumentPurpose::CalleeSaved, fp_csr);
         func.signature.params.push(csr_arg);
         func.signature.returns.push(csr_arg);
     }
@@ -852,7 +852,7 @@ fn insert_common_prologue(
 
         for reg in csrs.iter(FPR) {
             // Append param to entry Block
-            let csr_arg = pos.func.dfg.append_block_param(block, types::F64X2);
+            let csr_arg = pos.func.dfg.append_block_param(block, types::F64);
 
             // Assign it a location
             pos.func.locations[csr_arg] = ir::ValueLoc::Reg(reg);
@@ -1048,7 +1048,7 @@ fn insert_common_epilogue(
 
         for reg in csrs.iter(FPR) {
             let value = pos.ins().load(
-                types::F64X2,
+                types::F64,
                 ir::MemFlags::trusted(),
                 stack_addr,
                 fpr_offset,

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -857,7 +857,9 @@ fn insert_common_prologue(
             // Assign it a location
             pos.func.locations[csr_arg] = ir::ValueLoc::Reg(reg);
 
-            let reg_store_inst = pos.ins().store(ir::MemFlags::trusted(), csr_arg, stack_addr, fpr_offset);
+            let reg_store_inst =
+                pos.ins()
+                    .store(ir::MemFlags::trusted(), csr_arg, stack_addr, fpr_offset);
             fpr_offset += types::F64X2.bytes() as i32;
 
             if let Some(ref mut frame_layout) = pos.func.frame_layout {
@@ -1045,7 +1047,12 @@ fn insert_common_epilogue(
         pos.func.locations[stack_addr] = ir::ValueLoc::Reg(RU::rcx as u16);
 
         for reg in csrs.iter(FPR) {
-            let value = pos.ins().load(types::F64X2, ir::MemFlags::trusted(), stack_addr, fpr_offset);
+            let value = pos.ins().load(
+                types::F64X2,
+                ir::MemFlags::trusted(),
+                stack_addr,
+                fpr_offset,
+            );
             fpr_offset += types::F64X2.bytes() as i32;
 
             if let Some(ref mut cfa_state) = cfa_state.as_mut() {

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -626,8 +626,14 @@ fn fastcall_prologue_epilogue(func: &mut ir::Function, isa: &dyn TargetIsa) -> C
     // Set up the cursor and insert the prologue
     let entry_block = func.layout.entry_block().expect("missing entry block");
     let mut pos = EncCursor::new(func, isa).at_first_insertion_point(entry_block);
-    let prologue_cfa_state =
-        insert_common_prologue(&mut pos, local_stack_size, reg_type, &csrs, fpr_slot.as_ref(), isa);
+    let prologue_cfa_state = insert_common_prologue(
+        &mut pos,
+        local_stack_size,
+        reg_type,
+        &csrs,
+        fpr_slot.as_ref(),
+        isa,
+    );
 
     // Reset the cursor and insert the epilogue
     let mut pos = pos.at_position(CursorPosition::Nowhere);
@@ -886,7 +892,11 @@ fn insert_common_prologue(
         // `stack_store` is not directly encodable in x86_64 at the moment, so we'll need a base
         // address. We are well after postopt could run, so load the CSR region base once here,
         // instead of hoping that the addr/store will be combined later.
-        let stack_addr = pos.ins().stack_addr(types::I64, *fpr_slot.expect("if FPRs are preserved, a stack slot is allocated for them"), 0);
+        let stack_addr = pos.ins().stack_addr(
+            types::I64,
+            *fpr_slot.expect("if FPRs are preserved, a stack slot is allocated for them"),
+            0,
+        );
 
         // At this point we won't be using volatile registers for anything except for return
         // At this point we have not saved any CSRs yet, and arguments are all in registers. So
@@ -1010,7 +1020,11 @@ fn insert_common_epilogue(
         // `stack_store` is not directly encodable in x86_64 at the moment, so we'll need a base
         // address. We are well after postopt could run, so load the CSR region base once here,
         // instead of hoping that the addr/store will be combined later.
-        let stack_addr = pos.ins().stack_addr(types::I64, *fpr_slot.expect("if FPRs are preserved, a stack slot is allocated for them"), 0);
+        let stack_addr = pos.ins().stack_addr(
+            types::I64,
+            *fpr_slot.expect("if FPRs are preserved, a stack slot is allocated for them"),
+            0,
+        );
 
         // At this point we won't be using volatile registers for anything except for return
         // registers. Arbitrarily pick RBP as it won't hold an interesting value, and we're about

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -851,8 +851,8 @@ fn insert_common_prologue(
         pos.func.locations[stack_addr] = ir::ValueLoc::Reg(RU::rax as u16);
 
         for reg in csrs.iter(FPR) {
-            // Append param to entry EBB
-            let csr_arg = pos.func.dfg.append_ebb_param(ebb, types::F64X2);
+            // Append param to entry Block
+            let csr_arg = pos.func.dfg.append_block_param(block, types::F64X2);
 
             // Assign it a location
             pos.func.locations[csr_arg] = ir::ValueLoc::Reg(reg);

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -574,7 +574,7 @@ fn fastcall_prologue_epilogue(func: &mut ir::Function, isa: &dyn TargetIsa) -> C
         csr_stack_size += (num_fprs * types::F64X2.bytes() as usize) as i32;
 
         // Ensure that csr stack space is 16-byte aligned for ideal SIMD value placement.
-        csr_stack_size = csr_stack_size & !0b1111 + 16;
+        csr_stack_size = (csr_stack_size + 15) & !0b1111;
     }
 
     // TODO: eventually use the 32 bytes (shadow store) as spill slot. This currently doesn't work
@@ -732,7 +732,7 @@ fn insert_common_prologue(
                 total_stack_size += csrs.iter(FPR).len() as i64 * types::F64X2.bytes() as i64;
 
                 // Ensure that csr stack space is 16-byte aligned for ideal SIMD value placement.
-                total_stack_size = total_stack_size & !0b1111 + 16;
+                total_stack_size = (total_stack_size + 15) & !0b1111;
             }
 
             insert_stack_check(pos, total_stack_size, stack_limit_arg);

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -1042,9 +1042,9 @@ fn insert_common_epilogue(
         let stack_addr = pos.ins().stack_addr(types::I64, *csr_slot, 0);
 
         // At this point we won't be using volatile registers for anything except for return
-        // registers. Arbitrarily pick R11 as a volatile register that is not used for return
-        // values.
-        pos.func.locations[stack_addr] = ir::ValueLoc::Reg(RU::r11 as u16);
+        // registers. Arbitrarily pick RBP as it won't hold an interesting value, and we're about
+        // to restore it at the end of the function anyway.
+        pos.func.locations[stack_addr] = ir::ValueLoc::Reg(RU::rbp as u16);
 
         for reg in csrs.iter(FPR) {
             let value = pos.ins().load(

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -1042,9 +1042,9 @@ fn insert_common_epilogue(
         let stack_addr = pos.ins().stack_addr(types::I64, *csr_slot, 0);
 
         // At this point we won't be using volatile registers for anything except for return
-        // registers. Arbitrarily pick RCX as a volatile register that is not used for return
+        // registers. Arbitrarily pick R11 as a volatile register that is not used for return
         // values.
-        pos.func.locations[stack_addr] = ir::ValueLoc::Reg(RU::rcx as u16);
+        pos.func.locations[stack_addr] = ir::ValueLoc::Reg(RU::r11 as u16);
 
         for reg in csrs.iter(FPR) {
             let value = pos.ins().load(

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -608,10 +608,12 @@ fn fastcall_prologue_epilogue(func: &mut ir::Function, isa: &dyn TargetIsa) -> C
 
     for fp_csr in csrs.iter(FPR) {
         // The calling convention described in
-        // https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention only specifically
-        // discusses XMM6-XMM15, which are 128-bit registers. It may be sufficient to preserve only
-        // the low 128 bits here, but we may find that in practice we should preserve all of
-        // YMM6-15 (or even ZMM6-15?)
+        // https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention only requires
+        // preserving the low 128 bits of XMM6-XMM15.
+        //
+        // TODO: For now, add just an `F64` rather than `F64X2` because `F64X2` would require
+        // encoding a fstDisp8 with REX bits set, and we currently can't encode that. F64 causes a
+        // whole XMM register to be preserved anyway.
         let csr_arg =
             ir::AbiParam::special_reg(types::F64, ir::ArgumentPurpose::CalleeSaved, fp_csr);
         func.signature.params.push(csr_arg);

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -1047,12 +1047,9 @@ fn insert_common_epilogue(
         pos.func.locations[stack_addr] = ir::ValueLoc::Reg(RU::rbp as u16);
 
         for reg in csrs.iter(FPR) {
-            let value = pos.ins().load(
-                types::F64,
-                ir::MemFlags::trusted(),
-                stack_addr,
-                fpr_offset,
-            );
+            let value = pos
+                .ins()
+                .load(types::F64, ir::MemFlags::trusted(), stack_addr, fpr_offset);
             fpr_offset += types::F64X2.bytes() as i32;
 
             if let Some(ref mut cfa_state) = cfa_state.as_mut() {

--- a/cranelift-codegen/src/isa/x86/unwind.rs
+++ b/cranelift-codegen/src/isa/x86/unwind.rs
@@ -35,10 +35,23 @@ fn write_u32<T: ByteOrder>(sink: &mut dyn FrameUnwindSink, v: u32) {
 /// Note: the Cranelift x86 ISA RU enum matches the Windows unwind GPR encoding values.
 #[derive(Debug, PartialEq, Eq)]
 enum UnwindCode {
-    PushRegister { offset: u8, reg: RegUnit },
-    SaveXmm { offset: u8, reg: RegUnit, stack_offset: u32 },
-    StackAlloc { offset: u8, size: u32 },
-    SetFramePointer { offset: u8, sp_offset: u8 },
+    PushRegister {
+        offset: u8,
+        reg: RegUnit,
+    },
+    SaveXmm {
+        offset: u8,
+        reg: RegUnit,
+        stack_offset: u32,
+    },
+    StackAlloc {
+        offset: u8,
+        size: u32,
+    },
+    SetFramePointer {
+        offset: u8,
+        sp_offset: u8,
+    },
 }
 
 impl UnwindCode {
@@ -60,7 +73,11 @@ impl UnwindCode {
                     ((*reg as u8) << 4) | (UnwindOperation::PushNonvolatileRegister as u8),
                 );
             }
-            Self::SaveXmm { offset, reg, stack_offset } => {
+            Self::SaveXmm {
+                offset,
+                reg,
+                stack_offset,
+            } => {
                 write_u8(sink, *offset);
                 if *stack_offset <= core::u16::MAX as u32 {
                     write_u8(
@@ -123,7 +140,7 @@ impl UnwindCode {
                 } else {
                     3
                 }
-            },
+            }
             _ => 1,
         }
     }
@@ -228,7 +245,12 @@ impl UnwindInfo {
                         _ => {}
                     }
                 }
-                InstructionData::Store { opcode: Opcode::Store, args: [arg1, arg2], flags, offset } => {
+                InstructionData::Store {
+                    opcode: Opcode::Store,
+                    args: [arg1, _arg2],
+                    flags: _flags,
+                    offset,
+                } => {
                     if let ValueLoc::Reg(ru) = func.locations[arg1] {
                         let offset_int: i32 = offset.into();
                         assert!(offset_int >= 0);

--- a/cranelift-codegen/src/isa/x86/unwind.rs
+++ b/cranelift-codegen/src/isa/x86/unwind.rs
@@ -1,8 +1,8 @@
 //! Unwind information for x64 Windows.
 
-use super::registers::RU;
+use super::registers::{FPR, RU};
 use crate::binemit::FrameUnwindSink;
-use crate::ir::{Function, InstructionData, Opcode};
+use crate::ir::{Function, InstructionData, Opcode, ValueLoc};
 use crate::isa::{CallConv, RegUnit, TargetIsa};
 use alloc::vec::Vec;
 use byteorder::{ByteOrder, LittleEndian};
@@ -36,6 +36,7 @@ fn write_u32<T: ByteOrder>(sink: &mut dyn FrameUnwindSink, v: u32) {
 #[derive(Debug, PartialEq, Eq)]
 enum UnwindCode {
     PushRegister { offset: u8, reg: RegUnit },
+    SaveXmm { offset: u8, reg: RegUnit, stack_offset: u32 },
     StackAlloc { offset: u8, size: u32 },
     SetFramePointer { offset: u8, sp_offset: u8 },
 }
@@ -43,10 +44,12 @@ enum UnwindCode {
 impl UnwindCode {
     fn emit(&self, sink: &mut dyn FrameUnwindSink) {
         enum UnwindOperation {
-            PushNonvolatileRegister,
-            LargeStackAlloc,
-            SmallStackAlloc,
-            SetFramePointer,
+            PushNonvolatileRegister = 0,
+            LargeStackAlloc = 1,
+            SmallStackAlloc = 2,
+            SetFramePointer = 3,
+            SaveXmm128 = 8,
+            SaveXmm128Far = 9,
         }
 
         match self {
@@ -56,6 +59,23 @@ impl UnwindCode {
                     sink,
                     ((*reg as u8) << 4) | (UnwindOperation::PushNonvolatileRegister as u8),
                 );
+            }
+            Self::SaveXmm { offset, reg, stack_offset } => {
+                write_u8(sink, *offset);
+                if *stack_offset <= core::u16::MAX as u32 {
+                    write_u8(
+                        sink,
+                        ((*reg - FPR.first) << 4) as u8 | (UnwindOperation::SaveXmm128 as u8),
+                    );
+                    write_u16::<LittleEndian>(sink, *stack_offset as u16);
+                } else {
+                    write_u8(
+                        sink,
+                        ((*reg - FPR.first) << 4) as u8 | (UnwindOperation::SaveXmm128Far as u8),
+                    );
+                    write_u16::<LittleEndian>(sink, *stack_offset as u16);
+                    write_u16::<LittleEndian>(sink, (*stack_offset >> 16) as u16);
+                }
             }
             Self::StackAlloc { offset, size } => {
                 // Stack allocations on Windows must be a multiple of 8 and be at least 1 slot
@@ -97,6 +117,13 @@ impl UnwindCode {
                     3
                 }
             }
+            Self::SaveXmm { stack_offset, .. } => {
+                if *stack_offset <= core::u16::MAX as u32 {
+                    2
+                } else {
+                    3
+                }
+            },
             _ => 1,
         }
     }
@@ -199,6 +226,21 @@ impl UnwindInfo {
                             });
                         }
                         _ => {}
+                    }
+                }
+                InstructionData::Store { opcode: Opcode::Store, args: [arg1, arg2], flags, offset } => {
+                    if let ValueLoc::Reg(ru) = func.locations[arg1] {
+                        let offset_int: i32 = offset.into();
+                        assert!(offset_int >= 0);
+                        assert!(offset_int % 16 == 0);
+                        let scaled_offset = offset_int as u32 / 16;
+                        if FPR.contains(ru) {
+                            unwind_codes.push(UnwindCode::SaveXmm {
+                                offset: unwind_offset,
+                                reg: ru,
+                                stack_offset: scaled_offset,
+                            });
+                        }
                     }
                 }
                 _ => {}

--- a/cranelift-codegen/src/regalloc/register_set.rs
+++ b/cranelift-codegen/src/regalloc/register_set.rs
@@ -46,6 +46,11 @@ impl RegisterSet {
         Self { avail: [0; 3] }
     }
 
+    /// Returns `true` if all registers in this set are available.
+    pub fn is_empty(&self) -> bool {
+        self.avail == [0; 3]
+    }
+
     /// Returns `true` if the specified register is available.
     pub fn is_avail(&self, rc: RegClass, reg: RegUnit) -> bool {
         let (idx, bits) = bitmask(rc, reg);

--- a/cranelift-filetests/src/test_unwind.rs
+++ b/cranelift-filetests/src/test_unwind.rs
@@ -177,15 +177,15 @@ impl UnwindCode {
 
 #[derive(Debug)]
 enum UnwindOperation {
-    PushNonvolatileRegister,
-    LargeStackAlloc,
-    SmallStackAlloc,
-    SetFramePointer,
-    SaveNonvolatileRegister,
-    SaveNonvolatileRegisterFar,
-    SaveXmm128,
-    SaveXmm128Far,
-    PushMachineFrame,
+    PushNonvolatileRegister = 0,
+    LargeStackAlloc = 1,
+    SmallStackAlloc = 2,
+    SetFramePointer = 3,
+    SaveNonvolatileRegister = 4,
+    SaveNonvolatileRegisterFar = 5,
+    SaveXmm128 = 8,
+    SaveXmm128Far = 9,
+    PushMachineFrame = 10,
 }
 
 impl From<u8> for UnwindOperation {
@@ -198,9 +198,9 @@ impl From<u8> for UnwindOperation {
             3 => Self::SetFramePointer,
             4 => Self::SaveNonvolatileRegister,
             5 => Self::SaveNonvolatileRegisterFar,
-            6 => Self::SaveXmm128,
-            7 => Self::SaveXmm128Far,
-            8 => Self::PushMachineFrame,
+            8 => Self::SaveXmm128,
+            9 => Self::SaveXmm128Far,
+            10 => Self::PushMachineFrame,
             _ => panic!("unsupported unwind operation"),
         }
     }

--- a/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/filetests/isa/x86/windows_fastcall_x64.clif
@@ -48,8 +48,8 @@ ebb0(v0: f64, v1: f64, v2: f64, v3: f64):
 ; nextln:                         store notrap aligned v8, v7
 ; nextln:                         store notrap aligned v9, v7+16
 ; check:                          v11 = stack_addr.i64 ss0
-; nextln: [Op2fldDisp8#410,%xmm7] v13 = load.f64x2 notrap aligned v11+16
-; nextln: [Op2fld#410,%xmm6]      v12 = load.f64x2 notrap aligned v11
+; nextln:                         v13 = load.f64x2 notrap aligned v11+16
+; nextln:                         v12 = load.f64x2 notrap aligned v11
 ; nextln:                         v10 = x86_pop.i64
 ; nextln:                         v10, v12, v13
 

--- a/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/filetests/isa/x86/windows_fastcall_x64.clif
@@ -34,14 +34,14 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
 
 ; check that we preserve xmm6 and above if we're using them locally
 function %float_callee_saves(f64, f64, f64, f64) windows_fastcall {
-ebb0(v0: f64, v1: f64, v2: f64, v3: f64):
+block0(v0: f64, v1: f64, v2: f64, v3: f64):
 ; explicitly use a callee-save register
 [-, %xmm6]  v4 = fadd v0, v1
 [-, %xmm7]  v5 = fadd v0, v1
     return
 }
 ; check: function %float_callee_sav(f64 [%xmm0], f64 [%xmm1], f64 [%xmm2], f64 [%xmm3], i64 fp [%rbp], f64x2 csr [%xmm6], f64x2 csr [%xmm7]) -> i64 fp [%rbp], f64x2 csr [%xmm6], f64x2 csr [%xmm7] windows_fastcall {
-; check: ebb0(v0: f64 [%xmm0], v1: f64 [%xmm1], v2: f64 [%xmm2], v3: f64 [%xmm3], v6: i64 [%rbp], v8: f64x2 [%xmm6], v9: f64x2 [%xmm7]):
+; check: block0(v0: f64 [%xmm0], v1: f64 [%xmm1], v2: f64 [%xmm2], v3: f64 [%xmm3], v6: i64 [%rbp], v8: f64x2 [%xmm6], v9: f64x2 [%xmm7]):
 ; nextln:                         x86_push v6
 ; nextln:                         copy_special %rsp -> %rbp
 ; nextln:                         v7 = stack_addr.i64 ss0

--- a/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/filetests/isa/x86/windows_fastcall_x64.clif
@@ -32,6 +32,16 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
 }
 ; check: function %five_args(i64 [%rcx], i64 [%rdx], i64 [%r8], i64 [%r9], i64 [32], i64 fp [%rbp]) -> i64 fp [%rbp] windows_fastcall {
 
+; check that we preserve xmm6 and above if we're using them locally
+function %float_callee_saves(f64, f64, f64, f64) windows_fastcall {
+ebb0(v0: f64, v1: f64, v2: f64, v3: f64):
+[-, %xmm6]  v4 = fadd v0, v1      ; bin: 66 0f db f3
+;[-, %xmm6]  v5 = fadd v4, v2      ; bin: 66 0f db f3
+;[-, %xmm6]  v6 = fadd v5, v3      ; bin: 66 0f db f3
+    return
+}
+; check: function %float_callee_saves(f64 [%xmm0], f64 [%xmm1], f64 [%xmm2], f64 [%xmm3], f64 [%xmm6], i64 fp [%rbp]) -> i64 fp [%rbp] windows_fastcall {
+
 function %mixed_int_float(i64, f64, i64, f32) windows_fastcall {
 block0(v0: i64, v1: f64, v2: i64, v3: f32):
     return

--- a/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/filetests/isa/x86/windows_fastcall_x64.clif
@@ -41,6 +41,8 @@ block0(v0: f64, v1: f64, v2: f64, v3: f64):
     return
 }
 ; check: function %float_callee_sav(f64 [%xmm0], f64 [%xmm1], f64 [%xmm2], f64 [%xmm3], i64 fp [%rbp], f64 csr [%xmm6], f64 csr [%xmm7]) -> i64 fp [%rbp], f64 csr [%xmm6], f64 csr [%xmm7] windows_fastcall {
+; nextln:                         ss0 = spill_slot 32, offset -80
+; nextln:                         ss1 = incoming_arg 16, offset -48
 ; check: block0(v0: f64 [%xmm0], v1: f64 [%xmm1], v2: f64 [%xmm2], v3: f64 [%xmm3], v6: i64 [%rbp], v8: f64 [%xmm6], v9: f64 [%xmm7]):
 ; nextln:                         x86_push v6
 ; nextln:                         copy_special %rsp -> %rbp

--- a/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/filetests/isa/x86/windows_fastcall_x64.clif
@@ -40,16 +40,16 @@ block0(v0: f64, v1: f64, v2: f64, v3: f64):
 [-, %xmm7]  v5 = fadd v0, v1
     return
 }
-; check: function %float_callee_sav(f64 [%xmm0], f64 [%xmm1], f64 [%xmm2], f64 [%xmm3], i64 fp [%rbp], f64x2 csr [%xmm6], f64x2 csr [%xmm7]) -> i64 fp [%rbp], f64x2 csr [%xmm6], f64x2 csr [%xmm7] windows_fastcall {
-; check: block0(v0: f64 [%xmm0], v1: f64 [%xmm1], v2: f64 [%xmm2], v3: f64 [%xmm3], v6: i64 [%rbp], v8: f64x2 [%xmm6], v9: f64x2 [%xmm7]):
+; check: function %float_callee_sav(f64 [%xmm0], f64 [%xmm1], f64 [%xmm2], f64 [%xmm3], i64 fp [%rbp], f64 csr [%xmm6], f64 csr [%xmm7]) -> i64 fp [%rbp], f64 csr [%xmm6], f64 csr [%xmm7] windows_fastcall {
+; check: block0(v0: f64 [%xmm0], v1: f64 [%xmm1], v2: f64 [%xmm2], v3: f64 [%xmm3], v6: i64 [%rbp], v8: f64 [%xmm6], v9: f64 [%xmm7]):
 ; nextln:                         x86_push v6
 ; nextln:                         copy_special %rsp -> %rbp
 ; nextln:                         v7 = stack_addr.i64 ss0
 ; nextln:                         store notrap aligned v8, v7
 ; nextln:                         store notrap aligned v9, v7+16
 ; check:                          v11 = stack_addr.i64 ss0
-; nextln:                         v13 = load.f64x2 notrap aligned v11+16
-; nextln:                         v12 = load.f64x2 notrap aligned v11
+; nextln:                         v13 = load.f64 notrap aligned v11+16
+; nextln:                         v12 = load.f64 notrap aligned v11
 ; nextln:                         v10 = x86_pop.i64
 ; nextln:                         v10, v12, v13
 

--- a/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/filetests/isa/x86/windows_fastcall_x64.clif
@@ -44,14 +44,16 @@ block0(v0: f64, v1: f64, v2: f64, v3: f64):
 ; check: block0(v0: f64 [%xmm0], v1: f64 [%xmm1], v2: f64 [%xmm2], v3: f64 [%xmm3], v6: i64 [%rbp], v8: f64 [%xmm6], v9: f64 [%xmm7]):
 ; nextln:                         x86_push v6
 ; nextln:                         copy_special %rsp -> %rbp
+; nextln:                         adjust_sp_down_imm 64
 ; nextln:                         v7 = stack_addr.i64 ss0
 ; nextln:                         store notrap aligned v8, v7
 ; nextln:                         store notrap aligned v9, v7+16
-; check:                          v11 = stack_addr.i64 ss0
-; nextln:                         v13 = load.f64 notrap aligned v11+16
-; nextln:                         v12 = load.f64 notrap aligned v11
-; nextln:                         v10 = x86_pop.i64
-; nextln:                         v10, v12, v13
+; check:                          v10 = stack_addr.i64 ss0
+; nextln:                         v11 = load.f64 notrap aligned v10
+; nextln:                         v12 = load.f64 notrap aligned v10+16
+; nextln:                         adjust_sp_up_imm 64
+; nextln:                         v13 = x86_pop.i64
+; nextln:                         v13, v11, v12
 
 function %mixed_int_float(i64, f64, i64, f32) windows_fastcall {
 block0(v0: i64, v1: f64, v2: i64, v3: f32):

--- a/filetests/isa/x86/windows_fastcall_x64.clif
+++ b/filetests/isa/x86/windows_fastcall_x64.clif
@@ -35,12 +35,23 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
 ; check that we preserve xmm6 and above if we're using them locally
 function %float_callee_saves(f64, f64, f64, f64) windows_fastcall {
 ebb0(v0: f64, v1: f64, v2: f64, v3: f64):
-[-, %xmm6]  v4 = fadd v0, v1      ; bin: 66 0f db f3
-;[-, %xmm6]  v5 = fadd v4, v2      ; bin: 66 0f db f3
-;[-, %xmm6]  v6 = fadd v5, v3      ; bin: 66 0f db f3
+; explicitly use a callee-save register
+[-, %xmm6]  v4 = fadd v0, v1
+[-, %xmm7]  v5 = fadd v0, v1
     return
 }
-; check: function %float_callee_saves(f64 [%xmm0], f64 [%xmm1], f64 [%xmm2], f64 [%xmm3], f64 [%xmm6], i64 fp [%rbp]) -> i64 fp [%rbp] windows_fastcall {
+; check: function %float_callee_sav(f64 [%xmm0], f64 [%xmm1], f64 [%xmm2], f64 [%xmm3], i64 fp [%rbp], f64x2 csr [%xmm6], f64x2 csr [%xmm7]) -> i64 fp [%rbp], f64x2 csr [%xmm6], f64x2 csr [%xmm7] windows_fastcall {
+; check: ebb0(v0: f64 [%xmm0], v1: f64 [%xmm1], v2: f64 [%xmm2], v3: f64 [%xmm3], v6: i64 [%rbp], v8: f64x2 [%xmm6], v9: f64x2 [%xmm7]):
+; nextln:                         x86_push v6
+; nextln:                         copy_special %rsp -> %rbp
+; nextln:                         v7 = stack_addr.i64 ss0
+; nextln:                         store notrap aligned v8, v7
+; nextln:                         store notrap aligned v9, v7+16
+; check:                          v11 = stack_addr.i64 ss0
+; nextln: [Op2fldDisp8#410,%xmm7] v13 = load.f64x2 notrap aligned v11+16
+; nextln: [Op2fld#410,%xmm6]      v12 = load.f64x2 notrap aligned v11
+; nextln:                         v10 = x86_pop.i64
+; nextln:                         v10, v12, v13
 
 function %mixed_int_float(i64, f64, i64, f32) windows_fastcall {
 block0(v0: i64, v1: f64, v2: i64, v3: f32):

--- a/filetests/isa/x86/windows_fastcall_x64_unwind.clif
+++ b/filetests/isa/x86/windows_fastcall_x64_unwind.clif
@@ -134,6 +134,15 @@ block0(v0: i64, v1: i64):
     v12 = load.i32 v0+80
     v13 = load.i32 v0+88
     v14 = load.i32 v0+96
+    v15 = load.f64 v0+104
+    v16 = load.f64 v0+112
+    v17 = load.f64 v0+120
+    v18 = load.f64 v0+128
+    v19 = load.f64 v0+136
+    v20 = load.f64 v0+144
+    v21 = load.f64 v0+152
+    v22 = load.f64 v0+160
+    v23 = load.f64 v0+168
     store.i32 v2, v1+0
     store.i32 v3, v1+8
     store.i32 v4, v1+16
@@ -147,21 +156,54 @@ block0(v0: i64, v1: i64):
     store.i32 v12, v1+80
     store.i32 v13, v1+88
     store.i32 v14, v1+96
+    store.f64 v15, v1+104
+    store.f64 v16, v1+112
+    store.f64 v17, v1+120
+    store.f64 v18, v1+128
+    store.f64 v19, v1+136
+    store.f64 v20, v1+144
+    store.f64 v21, v1+152
+    store.f64 v22, v1+160
+    store.f64 v23, v1+168
     return
 }
 ; sameln: UnwindInfo {
 ; nextln:     version: 1,
 ; nextln:     flags: 0,
-; nextln:     prologue_size: 19,
-; nextln:     unwind_code_count_raw: 10,
+; nextln:     prologue_size: 42,
+; nextln:     unwind_code_count_raw: 16,
 ; nextln:     frame_register: 5,
 ; nextln:     frame_register_offset: 0,
 ; nextln:     unwind_codes: [
 ; nextln:         UnwindCode {
-; nextln:             offset: 19,
+; nextln:             offset: 42,
 ; nextln:             op: SmallStackAlloc,
-; nextln:             info: 3,
+; nextln:             info: 5,
 ; nextln:             value: None,
+; nextln:         },
+; nextln:         UnwindCode {
+; nextln:           offset: 38,
+; nextln:           op: SaveXmm128,
+; nextln:           info: 8,
+; nextln:           value: U16(
+; nextln:             2,
+; nextln:           ),
+; nextln:         },
+; nextln:         UnwindCode {
+; nextln:           offset: 32,
+; nextln:           op: SaveXmm128,
+; nextln:           info: 7,
+; nextln:           value: U16(
+; nextln:             1,
+; nextln:           ),
+; nextln:         },
+; nextln:         UnwindCode {
+; nextln:           offset: 27,
+; nextln:           op: SaveXmm128,
+; nextln:           info: 6,
+; nextln:           value: U16(
+; nextln:             0,
+; nextln:           ),
 ; nextln:         },
 ; nextln:         UnwindCode {
 ; nextln:             offset: 15,

--- a/filetests/isa/x86/windows_fastcall_x64_unwind.clif
+++ b/filetests/isa/x86/windows_fastcall_x64_unwind.clif
@@ -177,33 +177,33 @@ block0(v0: i64, v1: i64):
 ; nextln:     unwind_codes: [
 ; nextln:         UnwindCode {
 ; nextln:             offset: 42,
+; nextln:             op: SaveXmm128,
+; nextln:             info: 8,
+; nextln:             value: U16(
+; nextln:                 2,
+; nextln:             ),
+; nextln:           },
+; nextln:         UnwindCode {
+; nextln:             offset: 36,
+; nextln:             op: SaveXmm128,
+; nextln:             info: 7,
+; nextln:             value: U16(
+; nextln:                 1,
+; nextln:             ),
+; nextln:         },
+; nextln:         UnwindCode {
+; nextln:             offset: 31,
+; nextln:             op: SaveXmm128,
+; nextln:             info: 6,
+; nextln:             value: U16(
+; nextln:                 0,
+; nextln:             ),
+; nextln:         },
+; nextln:         UnwindCode {
+; nextln:             offset: 19,
 ; nextln:             op: SmallStackAlloc,
-; nextln:             info: 5,
+; nextln:             info: 12,
 ; nextln:             value: None,
-; nextln:         },
-; nextln:         UnwindCode {
-; nextln:           offset: 38,
-; nextln:           op: SaveXmm128,
-; nextln:           info: 8,
-; nextln:           value: U16(
-; nextln:             2,
-; nextln:           ),
-; nextln:         },
-; nextln:         UnwindCode {
-; nextln:           offset: 32,
-; nextln:           op: SaveXmm128,
-; nextln:           info: 7,
-; nextln:           value: U16(
-; nextln:             1,
-; nextln:           ),
-; nextln:         },
-; nextln:         UnwindCode {
-; nextln:           offset: 27,
-; nextln:           op: SaveXmm128,
-; nextln:           info: 6,
-; nextln:           value: U16(
-; nextln:             0,
-; nextln:           ),
 ; nextln:         },
 ; nextln:         UnwindCode {
 ; nextln:             offset: 15,


### PR DESCRIPTION
- [x] This has been discussed in issue #1366 
- [x] A short description: Windows appears to have extended ABI constraints to require callees to save XMM6-XMM15 (see #1366 for links to reference material). This PR adds preserve/restore behavior for those registers.
- [x] This PR contains test cases. Ish. There is an additional test that would test the right behavior if this was totally ready to go.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.

This is a draft PR as there are two points where I think I should just ask for help rather than spin my wheels figuring out the Right Thing, I'll add comments below.

@sstangl if you get a chance, I think you might know the right things for the questions to follow!