### PR TITLE
Fix inverted result of is_leaf method

### DIFF
--- a/cranelift-codegen/src/ir/function.rs
+++ b/cranelift-codegen/src/ir/function.rs
@@ -295,8 +295,8 @@ impl Function {
     /// to be confused with a "leaf function" in Windows terminology.
     pub fn is_leaf(&self) -> bool {
         // Conservative result: if there's at least one function signature referenced in this
-        // function, assume it may call.
-        !self.dfg.signatures.is_empty()
+        // function, assume it is not a leaf.
+        self.dfg.signatures.is_empty()
     }
 }
 

--- a/cranelift-codegen/src/stack_layout.rs
+++ b/cranelift-codegen/src/stack_layout.rs
@@ -47,7 +47,7 @@ pub fn layout_stack(
     let mut incoming_max = 0;
     let mut outgoing_max = 0;
     let mut min_align = alignment;
-    let mut must_align = is_leaf;
+    let mut must_align = !is_leaf;
 
     for slot in frame.values() {
         if slot.size > max_size {
@@ -145,7 +145,7 @@ mod tests {
         let sss = &mut StackSlots::new();
 
         // For all these test cases, assume it will call.
-        let is_leaf = true;
+        let is_leaf = false;
 
         // An empty layout should have 0-sized stack frame.
         assert_eq!(layout_stack(sss, is_leaf, 1), Ok(0));


### PR DESCRIPTION
- [x] This has been discussed in issue #1199.
- [x] A short description of what this does, why it is needed;  
Same as PR title.
- [x] This PR contains test cases, if meaningful.
- [x] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`.
