### PR TITLE
Add null pointer check for SimpleJitBuilder.symbol[s]

### DIFF
--- a/cranelift-simplejit/src/backend.rs
+++ b/cranelift-simplejit/src/backend.rs
@@ -90,7 +90,7 @@ impl SimpleJITBuilder {
     ///
     /// # Panics
     ///
-    /// Panics when ptr is NULL.
+    /// Panics when the symbol pointer is NULL.
     #[inline]
     pub unsafe fn symbol<K>(&mut self, name: K, ptr: *const u8) -> &Self
     where
@@ -107,7 +107,7 @@ impl SimpleJITBuilder {
     ///
     /// # Panics
     ///
-    /// Panics when ptr is NULL.
+    /// Panics whenever any symbol pointer is NULL.
     pub unsafe fn symbols<It, K>(&mut self, symbols: It) -> &Self
     where
         It: IntoIterator<Item = (K, *const u8)>,

--- a/cranelift-simplejit/src/backend.rs
+++ b/cranelift-simplejit/src/backend.rs
@@ -87,10 +87,16 @@ impl SimpleJITBuilder {
     /// back to a platform-specific search (this typically involves searching
     /// the current process for public symbols, followed by searching the
     /// platform's C runtime).
-    pub fn symbol<K>(&mut self, name: K, ptr: *const u8) -> &Self
+    ///
+    /// # Panics
+    ///
+    /// Panics when ptr is NULL.
+    #[inline]
+    pub unsafe fn symbol<K>(&mut self, name: K, ptr: *const u8) -> &Self
     where
         K: Into<String>,
     {
+        assert!(!ptr.is_null());
         self.symbols.insert(name.into(), ptr);
         self
     }
@@ -98,13 +104,17 @@ impl SimpleJITBuilder {
     /// Define multiple symbols in the internal symbol table.
     ///
     /// Using this is equivalent to calling `symbol` on each element.
-    pub fn symbols<It, K>(&mut self, symbols: It) -> &Self
+    ///
+    /// # Panics
+    ///
+    /// Panics when ptr is NULL.
+    pub unsafe fn symbols<It, K>(&mut self, symbols: It) -> &Self
     where
         It: IntoIterator<Item = (K, *const u8)>,
         K: Into<String>,
     {
         for (name, ptr) in symbols {
-            self.symbols.insert(name.into(), ptr);
+            self.symbol(name, ptr);
         }
         self
     }

--- a/cranelift-simplejit/tests/basic.rs
+++ b/cranelift-simplejit/tests/basic.rs
@@ -195,3 +195,11 @@ fn libcall_function() {
 
     module.finalize_definitions();
 }
+
+#[test]
+#[should_panic]
+fn create_null_symbol() {
+    let mut builder = SimpleJITBuilder::new(cranelift_module::default_libcall_names());
+    let ptr: *const u8 = std::ptr::null();
+    unsafe { builder.symbol("borked", ptr);  } ;
+}

--- a/cranelift-simplejit/tests/basic.rs
+++ b/cranelift-simplejit/tests/basic.rs
@@ -197,7 +197,7 @@ fn libcall_function() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "assertion failed: !ptr.is_null()")]
 fn create_null_symbol() {
     let mut builder = SimpleJITBuilder::new(cranelift_module::default_libcall_names());
     let ptr: *const u8 = std::ptr::null();

--- a/cranelift-simplejit/tests/basic.rs
+++ b/cranelift-simplejit/tests/basic.rs
@@ -201,5 +201,7 @@ fn libcall_function() {
 fn create_null_symbol() {
     let mut builder = SimpleJITBuilder::new(cranelift_module::default_libcall_names());
     let ptr: *const u8 = std::ptr::null();
-    unsafe { builder.symbol("borked", ptr);  } ;
+    unsafe {
+        builder.symbol("borked", ptr);
+    };
 }


### PR DESCRIPTION
This commit marks provides the `SimpleJitBuilder.symbol()` and `SimpleJitBuilder.symbols()` methods as unsafe, as markers to those embedding the crate. It also includes a null pointer assert! to abort illegal use of the methods.

As a driveby, the commit rewrites `symbols()` in terms of `symbol()`, removing some code duplication.

-  [x] This has been discussed in issue #798
- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [x] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.

<!-- Please ensure all communication adheres to the [code of
conduct](https://github.com/CraneStation/cranelift/blob/master/CODE_OF_CONDUCT.md). -->
