### PR TITLE
Don't return a Result for ObjectBuilder::new

### DIFF
--- a/cranelift-object/src/backend.rs
+++ b/cranelift-object/src/backend.rs
@@ -54,14 +54,14 @@ impl ObjectBuilder {
         name: String,
         collect_traps: ObjectTrapCollection,
         libcall_names: Box<dyn Fn(ir::LibCall) -> String>,
-    ) -> ModuleResult<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             isa,
             name,
             collect_traps,
             libcall_names,
             function_alignment: 1,
-        })
+        }
     }
 
     /// Set the alignment used for functions.


### PR DESCRIPTION
Since it always returned an `Ok(Self)`, there was no reason to have a
Result.

- [x] This has been discussed in issue #..., or if not, please tell us why
  here.

This is a small change that makes cranelift easier to use. It does not affect runtime behavior. Note that this is not backwards compatible.

- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.

This returns `Self` from ObjectBuilder::new instead of returning Result. Since `new()` can never fail, there's no reason to use Result.

- [x] This PR contains test cases, if meaningful.

N/A

- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.

r? @philipc
r? @bnjbvr 