### PR TITLE
Replace Gitter and IRC by a Bytecode Alliance Zulip stream link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,13 +13,11 @@ is reflected in the code or documentation yet. If you see things that seem
 missing or that don't make sense, or even that just don't work the way you
 expect them to, we're interested to hear about it!
 
-We have a [chat room on Gitter], and questions are also welcome as issues
-in the [Cranelift issue tracker]. Some folks also hang out in the #cranelift
-IRC channel on [irc.mozilla.org].
+We have a [stream] in the Bytecode Alliance Zulip instance, and questions are
+also welcome as issues in the [Cranelift issue tracker].
 
-[chat room on Gitter]: https://gitter.im/CraneStation/Lobby
+[stream]: https://bytecodealliance.zulipchat.com/#narrow/stream/217117-cranelift/topic/general
 [Cranelift issue tracker]: https://github.com/bytecodealliance/cranelift/issues/new
-[irc.mozilla.org]: https://wiki.mozilla.org/IRC
 
 ### Mentoring
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ into executable machine code.
 [![Documentation Status](https://readthedocs.org/projects/cranelift/badge/?version=latest)](https://cranelift.readthedocs.io/en/latest/?badge=latest)
 [![Build Status](https://github.com/bytecodealliance/cranelift/workflows/CI/badge.svg)](https://github.com/bytecodealliance/cranelift/actions)
 [![Fuzzit Status](https://app.fuzzit.dev/badge?org_id=bytecodealliance)](https://app.fuzzit.dev/orgs/bytecodealliance/dashboard)
-[![Gitter chat](https://badges.gitter.im/bytecodealliance/bytecodealliance.svg)](https://gitter.im/CraneStation/Lobby)
+[![Chat](https://img.shields.io/badge/chat-zulip-brightgreen.svg)](https://bytecodealliance.zulipchat.com/#narrow/stream/217117-cranelift/topic/general)
 ![Minimum rustc 1.37](https://img.shields.io/badge/rustc-1.37+-green.svg)
 
 For more information, see [the


### PR DESCRIPTION
The Bytecode Alliance will be using [Zulip](https://bytecodealliance.zulipchat.com/#narrow/stream/217117-cranelift/topic/general) for instant communication. There is a cranelift stream there, and a topic for general discussions. If you don't know about zulip, think of a stream as a collection of discussions around a general topic; then there's the ability to create specific topics within a given stream. I've added links in the README and CONTRIBUTING files of this repository, as a starting point.

[README rendered](https://github.com/bnjbvr/cranelift/blob/chat-room/README.md)

Till or Dan, can you have a look, please? Thanks!