### PR TITLE
add a "raw" function definition interface to cranelift-module

### DIFF
--- a/cranelift-faerie/src/traps.rs
+++ b/cranelift-faerie/src/traps.rs
@@ -24,6 +24,15 @@ impl FaerieTrapSink {
             code_size,
         }
     }
+
+    /// Create a `FaerieTrapSink` pre-populated with `traps`
+    pub fn new_with_sites(name: &str, code_size: u32, traps: Vec<TrapSite>) -> Self {
+        Self {
+            sites: traps,
+            name: name.to_owned(),
+            code_size,
+        }
+    }
 }
 
 impl binemit::TrapSink for FaerieTrapSink {

--- a/cranelift-faerie/src/traps.rs
+++ b/cranelift-faerie/src/traps.rs
@@ -2,17 +2,7 @@
 //! for every function in the module. This data may be useful at runtime.
 
 use cranelift_codegen::{binemit, ir};
-
-/// Record of the arguments cranelift passes to `TrapSink::trap`
-#[derive(Debug)]
-pub struct FaerieTrapSite {
-    /// Offset into function
-    pub offset: binemit::CodeOffset,
-    /// Source location given to cranelift
-    pub srcloc: ir::SourceLoc,
-    /// Trap code, as determined by cranelift
-    pub code: ir::TrapCode,
-}
+use cranelift_module::TrapSite;
 
 /// Record of the trap sites for a given function
 #[derive(Debug)]
@@ -22,7 +12,7 @@ pub struct FaerieTrapSink {
     /// Total code size of function
     pub code_size: u32,
     /// All trap sites collected in function
-    pub sites: Vec<FaerieTrapSite>,
+    pub sites: Vec<TrapSite>,
 }
 
 impl FaerieTrapSink {
@@ -38,7 +28,7 @@ impl FaerieTrapSink {
 
 impl binemit::TrapSink for FaerieTrapSink {
     fn trap(&mut self, offset: binemit::CodeOffset, srcloc: ir::SourceLoc, code: ir::TrapCode) {
-        self.sites.push(FaerieTrapSite {
+        self.sites.push(TrapSite {
             offset,
             srcloc,
             code,

--- a/cranelift-module/src/backend.rs
+++ b/cranelift-module/src/backend.rs
@@ -6,6 +6,7 @@ use crate::FuncId;
 use crate::Linkage;
 use crate::ModuleNamespace;
 use crate::ModuleResult;
+use crate::TrapSite;
 use core::marker;
 use cranelift_codegen::isa::TargetIsa;
 use cranelift_codegen::Context;
@@ -14,6 +15,7 @@ use cranelift_codegen::{binemit, ir};
 use std::borrow::ToOwned;
 use std::boxed::Box;
 use std::string::String;
+use std::vec::Vec;
 
 /// A `Backend` implements the functionality needed to support a `Module`.
 ///
@@ -83,6 +85,18 @@ where
         ctx: &Context,
         namespace: &ModuleNamespace<Self>,
         code_size: u32,
+    ) -> ModuleResult<Self::CompiledFunction>;
+
+    /// Define a function, taking the function body from the given `bytes`.
+    ///
+    /// Functions must be declared before being defined.
+    fn define_function_bytes(
+        &mut self,
+        id: FuncId,
+        name: &str,
+        bytes: &[u8],
+        namespace: &ModuleNamespace<Self>,
+        traps: Vec<TrapSite>,
     ) -> ModuleResult<Self::CompiledFunction>;
 
     /// Define a zero-initialized data object of the given size.

--- a/cranelift-module/src/lib.rs
+++ b/cranelift-module/src/lib.rs
@@ -35,6 +35,7 @@ use std::collections::{hash_map, HashMap};
 mod backend;
 mod data_context;
 mod module;
+mod traps;
 
 pub use crate::backend::{default_libcall_names, Backend};
 pub use crate::data_context::{DataContext, DataDescription, Init};
@@ -42,6 +43,7 @@ pub use crate::module::{
     DataId, FuncId, FuncOrDataId, Linkage, Module, ModuleError, ModuleFunction, ModuleNamespace,
     ModuleResult,
 };
+pub use crate::traps::TrapSite;
 
 /// Version number of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/cranelift-module/src/traps.rs
+++ b/cranelift-module/src/traps.rs
@@ -1,0 +1,14 @@
+//! Defines `TrapSite`.
+
+use cranelift_codegen::{binemit, ir};
+
+/// Record of the arguments cranelift passes to `TrapSink::trap`.
+#[derive(Clone, Debug)]
+pub struct TrapSite {
+    /// Offset into function.
+    pub offset: binemit::CodeOffset,
+    /// Source location given to cranelift.
+    pub srcloc: ir::SourceLoc,
+    /// Trap code, as determined by cranelift.
+    pub code: ir::TrapCode,
+}

--- a/cranelift-object/src/backend.rs
+++ b/cranelift-object/src/backend.rs
@@ -1,6 +1,6 @@
 //! Defines `ObjectBackend`.
 
-use crate::traps::{ObjectTrapSink, ObjectTrapSite};
+use crate::traps::ObjectTrapSink;
 use cranelift_codegen::binemit::{
     Addend, CodeOffset, NullStackmapSink, NullTrapSink, Reloc, RelocSink,
 };
@@ -9,7 +9,7 @@ use cranelift_codegen::isa::TargetIsa;
 use cranelift_codegen::{self, binemit, ir};
 use cranelift_module::{
     Backend, DataContext, DataDescription, DataId, FuncId, Init, Linkage, ModuleNamespace,
-    ModuleResult,
+    ModuleResult, TrapSite,
 };
 use object::write::{
     Object, Relocation, SectionId, StandardSection, Symbol, SymbolId, SymbolSection,
@@ -79,7 +79,7 @@ pub struct ObjectBackend {
     object: Object,
     functions: SecondaryMap<FuncId, Option<SymbolId>>,
     data_objects: SecondaryMap<DataId, Option<SymbolId>>,
-    traps: SecondaryMap<FuncId, Vec<ObjectTrapSite>>,
+    traps: SecondaryMap<FuncId, Vec<TrapSite>>,
     relocs: Vec<SymbolRelocs>,
     libcalls: HashMap<ir::LibCall, SymbolId>,
     libcall_names: Box<dyn Fn(ir::LibCall) -> String>,
@@ -462,7 +462,7 @@ pub struct ObjectProduct {
     /// Symbol IDs for data objects (both declared and defined).
     pub data_objects: SecondaryMap<DataId, Option<SymbolId>>,
     /// Trap sites for defined functions.
-    pub traps: SecondaryMap<FuncId, Vec<ObjectTrapSite>>,
+    pub traps: SecondaryMap<FuncId, Vec<TrapSite>>,
 }
 
 impl ObjectProduct {

--- a/cranelift-object/src/backend.rs
+++ b/cranelift-object/src/backend.rs
@@ -226,6 +226,23 @@ impl Backend for ObjectBackend {
         Ok(ObjectCompiledFunction)
     }
 
+    fn define_function_bytes(
+        &mut self,
+        func_id: FuncId,
+        _name: &str,
+        bytes: &[u8],
+        _namespace: &ModuleNamespace<Self>,
+        traps: Vec<TrapSite>,
+    ) -> ModuleResult<ObjectCompiledFunction> {
+        let symbol = self.functions[func_id].unwrap();
+        let section = self.object.section_id(StandardSection::Text);
+        let _offset = self
+            .object
+            .add_symbol_data(symbol, section, bytes, self.function_alignment);
+        self.traps[func_id] = traps;
+        Ok(ObjectCompiledFunction)
+    }
+
     fn define_data(
         &mut self,
         data_id: DataId,

--- a/cranelift-object/src/lib.rs
+++ b/cranelift-object/src/lib.rs
@@ -29,7 +29,7 @@ mod backend;
 mod traps;
 
 pub use crate::backend::{ObjectBackend, ObjectBuilder, ObjectProduct, ObjectTrapCollection};
-pub use crate::traps::{ObjectTrapSink, ObjectTrapSite};
+pub use crate::traps::ObjectTrapSink;
 
 /// Version number of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/cranelift-object/src/traps.rs
+++ b/cranelift-object/src/traps.rs
@@ -2,28 +2,18 @@
 //! for every function in the module. This data may be useful at runtime.
 
 use cranelift_codegen::{binemit, ir};
-
-/// Record of the arguments cranelift passes to `TrapSink::trap`
-#[derive(Clone)]
-pub struct ObjectTrapSite {
-    /// Offset into function
-    pub offset: binemit::CodeOffset,
-    /// Source location given to cranelift
-    pub srcloc: ir::SourceLoc,
-    /// Trap code, as determined by cranelift
-    pub code: ir::TrapCode,
-}
+use cranelift_module::TrapSite;
 
 /// Record of the trap sites for a given function
 #[derive(Default, Clone)]
 pub struct ObjectTrapSink {
     /// All trap sites collected in function
-    pub sites: Vec<ObjectTrapSite>,
+    pub sites: Vec<TrapSite>,
 }
 
 impl binemit::TrapSink for ObjectTrapSink {
     fn trap(&mut self, offset: binemit::CodeOffset, srcloc: ir::SourceLoc, code: ir::TrapCode) {
-        self.sites.push(ObjectTrapSite {
+        self.sites.push(TrapSite {
             offset,
             srcloc,
             code,

--- a/cranelift-simplejit/src/backend.rs
+++ b/cranelift-simplejit/src/backend.rs
@@ -8,7 +8,7 @@ use cranelift_codegen::isa::TargetIsa;
 use cranelift_codegen::{self, ir, settings};
 use cranelift_module::{
     Backend, DataContext, DataDescription, DataId, FuncId, Init, Linkage, ModuleNamespace,
-    ModuleResult,
+    ModuleResult, TrapSite,
 };
 use cranelift_native;
 #[cfg(not(windows))]
@@ -191,6 +191,18 @@ impl SimpleJITBackend {
             _ => panic!("invalid ExternalName {}", name),
         }
     }
+
+    fn record_function_for_perf(&self, ptr: *mut u8, size: usize, name: &str) {
+        if cfg!(target_os = "linux") && ::std::env::var_os("PERF_BUILDID_DIR").is_some() {
+            let mut map_file = ::std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(format!("/tmp/perf-{}.map", ::std::process::id()))
+                .unwrap();
+
+            let _ = writeln!(map_file, "{:x} {:x} {}", ptr as usize, size, name);
+        }
+    }
 }
 
 impl<'simple_jit_backend> Backend for SimpleJITBackend {
@@ -267,15 +279,7 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
             .allocate(size, EXECUTABLE_DATA_ALIGNMENT)
             .expect("TODO: handle OOM etc.");
 
-        if cfg!(target_os = "linux") && ::std::env::var_os("PERF_BUILDID_DIR").is_some() {
-            let mut map_file = ::std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(format!("/tmp/perf-{}.map", ::std::process::id()))
-                .unwrap();
-
-            let _ = writeln!(map_file, "{:x} {:x} {}", ptr as usize, code_size, name);
-        }
+        self.record_function_for_perf(ptr, size, name);
 
         let mut reloc_sink = SimpleJITRelocSink::new();
         // Ignore traps for now. For now, frontends should just avoid generating code
@@ -296,6 +300,34 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
             code: ptr,
             size,
             relocs: reloc_sink.relocs,
+        })
+    }
+
+    fn define_function_bytes(
+        &mut self,
+        _id: FuncId,
+        name: &str,
+        bytes: &[u8],
+        _namespace: &ModuleNamespace<Self>,
+        _traps: Vec<TrapSite>,
+    ) -> ModuleResult<Self::CompiledFunction> {
+        let size = bytes.len();
+        let ptr = self
+            .memory
+            .code
+            .allocate(size, EXECUTABLE_DATA_ALIGNMENT)
+            .expect("TODO: handle OOM etc.");
+
+        self.record_function_for_perf(ptr, size, name);
+
+        unsafe {
+            ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, size);
+        }
+
+        Ok(Self::CompiledFunction {
+            code: ptr,
+            size,
+            relocs: vec![],
         })
     }
 

--- a/cranelift-simplejit/src/backend.rs
+++ b/cranelift-simplejit/src/backend.rs
@@ -193,6 +193,11 @@ impl SimpleJITBackend {
     }
 
     fn record_function_for_perf(&self, ptr: *mut u8, size: usize, name: &str) {
+        // The Linux perf tool supports JIT code via a /tmp/perf-$PID.map file,
+        // which contains memory regions and their associated names.  If we
+        // are profiling with perf and saving binaries to PERF_BUILDID_DIR
+        // for post-profile analysis, write information about each function
+        // we define.
         if cfg!(target_os = "linux") && ::std::env::var_os("PERF_BUILDID_DIR").is_some() {
             let mut map_file = ::std::fs::OpenOptions::new()
                 .create(true)


### PR DESCRIPTION
- [X] This has been discussed in issue #1386.
- [X] A short description of what this does, why it is needed: for certain functions (`lucet`'s stack probe code is the motivating example), generating them via cranelift is not necessarily feasible.  Other compilers have recognized this and provided inline assembly for such cases.  This interface can be thought of as a very primitive form of inline assembly (and a limited form; e.g. relocations are not currently supported).  The overarching intent is to make `cranelift-module`'s API rich enough that `lucet` can operate entirely within `cranelift-module`'s API and not have to drop down to `faerie` or `object`.  See #1386 for more details.
- [X] This PR does not contain test cases.
- [X] A reviewer from the core maintainer team has been assigned for this PR.