### PR TITLE
Update to wasmparser 0.51

### DIFF
--- a/cranelift-wasm/Cargo.toml
+++ b/cranelift-wasm/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["webassembly", "wasm"]
 edition = "2018"
 
 [dependencies]
-wasmparser = { version = "0.49.0", default-features = false }
+wasmparser = { version = "0.51.0", default-features = false }
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.58.0", default-features = false }
 cranelift-entity = { path = "../cranelift-entity", version = "0.58.0" }
 cranelift-frontend = { path = "../cranelift-frontend", version = "0.58.0", default-features = false }

--- a/cranelift-wasm/src/environ/spec.rs
+++ b/cranelift-wasm/src/environ/spec.rs
@@ -55,7 +55,7 @@ pub enum WasmError {
     #[error("Invalid input WebAssembly code at offset {offset}: {message}")]
     InvalidWebAssembly {
         /// A string describing the validation error.
-        message: &'static str,
+        message: std::string::String,
         /// The bytecode offset where the error occurred.
         offset: usize,
     },
@@ -90,8 +90,10 @@ macro_rules! wasm_unsupported {
 impl From<BinaryReaderError> for WasmError {
     /// Convert from a `BinaryReaderError` to a `WasmError`.
     fn from(e: BinaryReaderError) -> Self {
-        let BinaryReaderError { message, offset } = e;
-        Self::InvalidWebAssembly { message, offset }
+        Self::InvalidWebAssembly {
+            message: e.message().into(),
+            offset: e.offset(),
+        }
     }
 }
 


### PR DESCRIPTION
wasmparser::BinaryReaderError now encapsulates its fields, so call the
accessors rather than destructuring to get the fields.