### PR TITLE
Allow modules to have names of arbitrary bytes

### DIFF
--- a/cranelift-object/src/backend.rs
+++ b/cranelift-object/src/backend.rs
@@ -32,7 +32,7 @@ pub enum ObjectTrapCollection {
 /// A builder for `ObjectBackend`.
 pub struct ObjectBuilder {
     isa: Box<dyn TargetIsa>,
-    name: String,
+    name: Vec<u8>,
     collect_traps: ObjectTrapCollection,
     libcall_names: Box<dyn Fn(ir::LibCall) -> String>,
     function_alignment: u64,
@@ -49,15 +49,15 @@ impl ObjectBuilder {
     /// enum to symbols. LibCalls are inserted in the IR as part of the legalization for certain
     /// floating point instructions, and for stack probes. If you don't know what to use for this
     /// argument, use `cranelift_module::default_libcall_names()`.
-    pub fn new(
+    pub fn new<V: Into<Vec<u8>>>(
         isa: Box<dyn TargetIsa>,
-        name: String,
+        name: V,
         collect_traps: ObjectTrapCollection,
         libcall_names: Box<dyn Fn(ir::LibCall) -> String>,
     ) -> Self {
         Self {
             isa,
-            name,
+            name: name.into(),
             collect_traps,
             libcall_names,
             function_alignment: 1,
@@ -104,7 +104,7 @@ impl Backend for ObjectBackend {
     fn new(builder: ObjectBuilder) -> Self {
         let triple = builder.isa.triple();
         let mut object = Object::new(triple.binary_format, triple.architecture);
-        object.add_file_symbol(builder.name.as_bytes().to_vec());
+        object.add_file_symbol(builder.name);
         Self {
             isa: builder.isa,
             object,


### PR DESCRIPTION
- [x] This has been discussed in issue #..., or if not, please tell us why
  here.

This is a minor change and is backwards compatible.

- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.

This is useful for me because I name the module after the file, which
comes from the filesystem and may not be valid UTF8.

Also, this removes a needless copy in ObjectBackend::new (`.to_vec()` copies the slice).

- [ ] This PR contains test cases, if meaningful.

N/A

- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.

r? @philipc